### PR TITLE
added jvm arguments to tasks of type JavaExec to enable a JDK9 runtim…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ subprojects {
         manifest.attributes provider: 'gradle'
     }
 
-    compileJava {
+    tasks.withType(JavaCompile) {
         options.compilerArgs << "-Xlint:all"
         options.compilerArgs << "-Werror"
     } 
@@ -45,6 +45,11 @@ subprojects {
             xml.enabled = false
             html.enabled = true
         }
+    }
+    
+    tasks.withType(JavaExec) {
+        jvmArgs "-XX:+IgnoreUnrecognizedVMOptions"
+        jvmArgs "--add-modules", "java.xml.bind"
     }
 }
 


### PR DESCRIPTION
…e. if no JDK9 runtime is used the --add-modules vm option will be ignored

fixes TweetWallFX/TweetwallFX#141