### PR TITLE
in case of truncated URL or Media Entries the twitter api does not de…

### DIFF
--- a/controls/src/main/java/org/tweetwallfx/controls/dataprovider/TagCloudDataProvider.java
+++ b/controls/src/main/java/org/tweetwallfx/controls/dataprovider/TagCloudDataProvider.java
@@ -23,27 +23,19 @@
  */
 package org.tweetwallfx.controls.dataprovider;
 
-import java.util.Arrays;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
-import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import org.tweetwallfx.controls.Word;
 import org.tweetwallfx.tweet.StopList;
 import org.tweetwallfx.tweet.TweetSetData;
 import org.tweetwallfx.tweet.api.Tweet;
-import org.tweetwallfx.tweet.api.TweetQuery;
 import org.tweetwallfx.tweet.api.TweetStream;
 import org.tweetwallfx.tweet.api.entry.MediaTweetEntry;
 import org.tweetwallfx.tweet.api.entry.UrlTweetEntry;
 import org.tweetwallfx.tweet.api.entry.UserMentionTweetEntry;
 
-/**
- *
- * @author sven
- */
 public class TagCloudDataProvider implements DataProvider{
 
     private final static int NUM_MAX_WORDS = 40;
@@ -83,6 +75,7 @@ public class TagCloudDataProvider implements DataProvider{
                 .replaceAll("[.,!?:´`']((\\s+)|($))", " ")
                 .replaceAll("['\"()]", " "))
                 .filter(l -> l.length() > 2)
+                .filter(StopList.IS_NOT_URL) // no url or part thereof
                 .map(String::toLowerCase)
                 .map(StopList::removeEmojis)
                 .filter(StopList::notIn)                

--- a/controls/src/main/java/org/tweetwallfx/controls/steps/AddTweetToCloudStep.java
+++ b/controls/src/main/java/org/tweetwallfx/controls/steps/AddTweetToCloudStep.java
@@ -23,11 +23,9 @@
  */
 package org.tweetwallfx.controls.steps;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
-import javafx.application.Platform;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 import org.tweetwallfx.controls.Word;
@@ -38,13 +36,10 @@ import org.tweetwallfx.controls.stepengine.AbstractStep;
 import org.tweetwallfx.controls.stepengine.StepEngine.MachineContext;
 import org.tweetwallfx.tweet.StopList;
 import org.tweetwallfx.tweet.api.Tweet;
+import org.tweetwallfx.tweet.api.entry.MediaTweetEntry;
 import org.tweetwallfx.tweet.api.entry.UrlTweetEntry;
 import org.tweetwallfx.tweet.api.entry.UserMentionTweetEntry;
 
-/**
- *
- * @author Jörg Michelberger
- */
 public class AddTweetToCloudStep extends AbstractStep {
 
     private static final Logger log = LogManager.getLogger(AddTweetToCloudStep.class);
@@ -59,12 +54,13 @@ public class AddTweetToCloudStep extends AbstractStep {
         WordleSkin wordleSkin = (WordleSkin) context.get("WordleSkin");
         Tweet tweetInfo = wordleSkin.getSkinnable().getDataProvider(TweetDataProvider.class).getTweet();
         String text = tweetInfo.getTextWithout(UrlTweetEntry.class)
+                .getTextWithout(MediaTweetEntry.class)
                 .getTextWithout(UserMentionTweetEntry.class)
                 .get();
         Set<Word> tweetWords = StopList.WORD_SPLIT.splitAsStream(text)
                 .map(StopList::trimTail) //no bad word tails
                 .filter(l -> l.length() > 2) //longer than 2 characters
-                .filter(StopList.IS_NOT_URL) //no url
+                .filter(StopList.IS_NOT_URL) // no url or part thereof
 //                .filter(StopList::notIn) //not in stoplist
                 .map(l -> new Word(l, 0.1)) //convert to Word
                 .collect(Collectors.toSet());                   //collect


### PR DESCRIPTION
…clare the truncated part to be a URL or Media Entry. Thus programatic removal via getTextWithout(Class) does not work as that function has nothing of those entry types it can remove.

It is therefore correct to check that a word is not a URL (i.e. start with "http:").
fixes TweetWallFX/TweetwallFX#151