### PR TITLE
added method (with default empty implementation) to Step.Factory whic…

### DIFF
--- a/controls/src/main/java/org/tweetwallfx/controls/stepengine/Step.java
+++ b/controls/src/main/java/org/tweetwallfx/controls/stepengine/Step.java
@@ -24,6 +24,9 @@
 package org.tweetwallfx.controls.stepengine;
 
 import java.time.Duration;
+import java.util.Collection;
+import java.util.Collections;
+import org.tweetwallfx.controls.dataprovider.DataProvider;
 import org.tweetwallfx.controls.stepengine.StepEngine.MachineContext;
 import org.tweetwallfx.controls.stepengine.config.StepEngineSettings;
 
@@ -74,11 +77,33 @@ public interface Step {
         /**
          * Creates a Step.
          *
-         * @param stepSettings the settings object for which the Step is to be
+         * @param stepDefinition the settings object for which the Step is to be
          * created
          *
          * @return the created Step
          */
-        Step create(final StepEngineSettings.StepDefinition stepSettings);
+        Step create(final StepEngineSettings.StepDefinition stepDefinition);
+
+        /**
+         * Retrieves the classes of {@link DataProvider DataProviders} required
+         * by the created {@link Step}.
+         * <p>
+         *
+         * <b>Important: Any {@link DataProvider} that is used must be contained
+         * within the returned Collection in order to be certain that the
+         * DataProvider is instantiated. If it is not declared to be required it
+         * is highly likely that it will not be instantiated and thus produce a
+         * {@link NullPointerException} downstream.</b>
+         *
+         * @param stepDefinition the settings object for which the Step is to be
+         * created
+         *
+         * @return a Collection containing the classes of
+         * {@link DataProvider DataProviders} required by the created
+         * {@link Step}
+         */
+        default Collection<Class<? extends DataProvider>> getRequiredDataProviders(final StepEngineSettings.StepDefinition stepDefinition) {
+            return Collections.emptyList();
+        }
     }
 }

--- a/controls/src/main/java/org/tweetwallfx/controls/stepengine/StepEngine.java
+++ b/controls/src/main/java/org/tweetwallfx/controls/stepengine/StepEngine.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright 2014-2015 TweetWallFX
+ * Copyright 2014-2017 TweetWallFX
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.ServiceLoader;
+import java.util.Set;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
@@ -74,6 +75,7 @@ public final class StepEngine {
     }
 
     private void initDataProviders() {
+        final Set<Class<? extends DataProvider>> requiredDataProviders = stateIterator.getRequiredDataProviders();
         STARTUP_LOGGER.info("create TweetStream");
 
         final String searchText = Configuration.getInstance().getConfigTyped(TweetwallSettings.CONFIG_KEY, TweetwallSettings.class).getQuery();
@@ -84,9 +86,18 @@ public final class StepEngine {
 
         STARTUP_LOGGER.info("create DataProviders");
         final List<DataProvider> providers = StreamSupport.stream(ServiceLoader.load(DataProvider.Factory.class).spliterator(), false)
+                .filter(factory -> requiredDataProviders.contains(factory.getDataProviderClass()))
                 .map(factory -> factory.create(tweetStream))
                 .peek(dataProvider -> LOG.info("created " + dataProvider))
                 .collect(Collectors.toList());
+
+        requiredDataProviders.stream()
+                .filter(rdpc -> !providers.stream().anyMatch(rdpc::isInstance))
+                .findAny()
+                .ifPresent(rdpc -> {
+                    throw new IllegalStateException("DataProvider '" + rdpc.getCanonicalName() + "' is required but no DataProvider.Factory was found creating it!");
+                });
+
         final List<DataProvider.HistoryAware> historyAwareProviders = providers.stream()
                 .filter(DataProvider.HistoryAware.class::isInstance)
                 .map(DataProvider.HistoryAware.class::cast)
@@ -132,7 +143,7 @@ public final class StepEngine {
                     .filter(klazz::isInstance)
                     .map(klazz::cast)
                     .findFirst()
-                    .orElse(null);
+                    .orElseThrow(() -> new IllegalStateException("A DataProvider of type '" + klazz.getName() + "' has not been registered."));
         }
     }
 

--- a/controls/src/main/java/org/tweetwallfx/controls/steps/AddTweetToCloudStep.java
+++ b/controls/src/main/java/org/tweetwallfx/controls/steps/AddTweetToCloudStep.java
@@ -23,12 +23,15 @@
  */
 package org.tweetwallfx.controls.steps;
 
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.tweetwallfx.controls.Word;
+import org.tweetwallfx.controls.dataprovider.DataProvider;
 import org.tweetwallfx.controls.dataprovider.TagCloudDataProvider;
 import org.tweetwallfx.controls.dataprovider.TweetDataProvider;
 import org.tweetwallfx.controls.stepengine.Step;
@@ -87,6 +90,11 @@ public class AddTweetToCloudStep implements Step {
         @Override
         public Class<AddTweetToCloudStep> getStepClass() {
             return AddTweetToCloudStep.class;
+        }
+
+        @Override
+        public Collection<Class<? extends DataProvider>> getRequiredDataProviders(final StepEngineSettings.StepDefinition stepSettings) {
+            return Arrays.asList(TweetDataProvider.class, TagCloudDataProvider.class);
         }
     }
 }

--- a/controls/src/main/java/org/tweetwallfx/controls/steps/CloudToCloudStep.java
+++ b/controls/src/main/java/org/tweetwallfx/controls/steps/CloudToCloudStep.java
@@ -24,6 +24,8 @@
 package org.tweetwallfx.controls.steps;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -37,6 +39,7 @@ import javafx.util.Duration;
 import org.tweetwallfx.controls.Word;
 import org.tweetwallfx.controls.WordleLayout;
 import org.tweetwallfx.controls.WordleSkin;
+import org.tweetwallfx.controls.dataprovider.DataProvider;
 import org.tweetwallfx.controls.dataprovider.TagCloudDataProvider;
 import org.tweetwallfx.controls.stepengine.Step;
 import org.tweetwallfx.controls.stepengine.StepEngine.MachineContext;
@@ -164,6 +167,11 @@ public class CloudToCloudStep implements Step {
         @Override
         public Class<CloudToCloudStep> getStepClass() {
             return CloudToCloudStep.class;
+        }
+
+        @Override
+        public Collection<Class<? extends DataProvider>> getRequiredDataProviders(final StepEngineSettings.StepDefinition stepSettings) {
+            return Arrays.asList(TagCloudDataProvider.class);
         }
     }
 }

--- a/controls/src/main/java/org/tweetwallfx/controls/steps/CloudToTweetStep.java
+++ b/controls/src/main/java/org/tweetwallfx/controls/steps/CloudToTweetStep.java
@@ -26,6 +26,8 @@ package org.tweetwallfx.controls.steps;
 import de.jensd.fx.glyphs.GlyphsStack;
 import de.jensd.fx.glyphs.fontawesome.FontAwesomeIconView;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import javafx.animation.FadeTransition;
 import javafx.animation.ParallelTransition;
@@ -50,6 +52,7 @@ import org.tweetwallfx.controls.TweetLayout;
 import org.tweetwallfx.controls.TweetWordNodeFactory;
 import org.tweetwallfx.controls.Word;
 import org.tweetwallfx.controls.WordleSkin;
+import org.tweetwallfx.controls.dataprovider.DataProvider;
 import org.tweetwallfx.controls.dataprovider.TweetDataProvider;
 import org.tweetwallfx.controls.stepengine.Step;
 import org.tweetwallfx.controls.stepengine.StepEngine.MachineContext;
@@ -361,6 +364,11 @@ public class CloudToTweetStep implements Step {
         @Override
         public Class<CloudToTweetStep> getStepClass() {
             return CloudToTweetStep.class;
+        }
+
+        @Override
+        public Collection<Class<? extends DataProvider>> getRequiredDataProviders(final StepEngineSettings.StepDefinition stepSettings) {
+            return Arrays.asList(TweetDataProvider.class);
         }
     }
 }

--- a/controls/src/main/java/org/tweetwallfx/controls/steps/FadeInCloudStep.java
+++ b/controls/src/main/java/org/tweetwallfx/controls/steps/FadeInCloudStep.java
@@ -24,6 +24,8 @@
 package org.tweetwallfx.controls.steps;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -37,6 +39,7 @@ import javafx.util.Duration;
 import org.tweetwallfx.controls.Word;
 import org.tweetwallfx.controls.WordleLayout;
 import org.tweetwallfx.controls.WordleSkin;
+import org.tweetwallfx.controls.dataprovider.DataProvider;
 import org.tweetwallfx.controls.dataprovider.TagCloudDataProvider;
 import org.tweetwallfx.controls.stepengine.Step;
 import org.tweetwallfx.controls.stepengine.StepEngine.MachineContext;
@@ -124,6 +127,11 @@ public class FadeInCloudStep implements Step {
         @Override
         public Class<FadeInCloudStep> getStepClass() {
             return FadeInCloudStep.class;
+        }
+
+        @Override
+        public Collection<Class<? extends DataProvider>> getRequiredDataProviders(final StepEngineSettings.StepDefinition stepSettings) {
+            return Arrays.asList(TagCloudDataProvider.class);
         }
     }
 }

--- a/controls/src/main/java/org/tweetwallfx/controls/steps/ImageMosaicStep.java
+++ b/controls/src/main/java/org/tweetwallfx/controls/steps/ImageMosaicStep.java
@@ -24,6 +24,8 @@
 package org.tweetwallfx.controls.steps;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -43,6 +45,7 @@ import javafx.scene.image.ImageView;
 import javafx.scene.layout.Pane;
 import javafx.util.Duration;
 import org.tweetwallfx.controls.WordleSkin;
+import org.tweetwallfx.controls.dataprovider.DataProvider;
 import org.tweetwallfx.controls.dataprovider.ImageMosaicDataProvider;
 import org.tweetwallfx.controls.dataprovider.ImageMosaicDataProvider.ImageStore;
 import org.tweetwallfx.controls.stepengine.Step;
@@ -309,6 +312,11 @@ public class ImageMosaicStep implements Step {
         @Override
         public Class<ImageMosaicStep> getStepClass() {
             return ImageMosaicStep.class;
+        }
+
+        @Override
+        public Collection<Class<? extends DataProvider>> getRequiredDataProviders(final StepEngineSettings.StepDefinition stepSettings) {
+            return Arrays.asList(ImageMosaicDataProvider.class);
         }
     }
 }

--- a/controls/src/main/java/org/tweetwallfx/controls/steps/NextTweetStep.java
+++ b/controls/src/main/java/org/tweetwallfx/controls/steps/NextTweetStep.java
@@ -23,6 +23,9 @@
  */
 package org.tweetwallfx.controls.steps;
 
+import java.util.Arrays;
+import java.util.Collection;
+import org.tweetwallfx.controls.dataprovider.DataProvider;
 import org.tweetwallfx.controls.dataprovider.TweetDataProvider;
 import org.tweetwallfx.controls.stepengine.Step;
 import org.tweetwallfx.controls.stepengine.StepEngine.MachineContext;
@@ -57,6 +60,11 @@ public class NextTweetStep implements Step {
         @Override
         public Class<NextTweetStep> getStepClass() {
             return NextTweetStep.class;
+        }
+
+        @Override
+        public Collection<Class<? extends DataProvider>> getRequiredDataProviders(final StepEngineSettings.StepDefinition stepSettings) {
+            return Arrays.asList(TweetDataProvider.class);
         }
     }
 }

--- a/controls/src/main/java/org/tweetwallfx/controls/steps/TweetToCloudStep.java
+++ b/controls/src/main/java/org/tweetwallfx/controls/steps/TweetToCloudStep.java
@@ -24,6 +24,8 @@
 package org.tweetwallfx.controls.steps;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
@@ -40,6 +42,7 @@ import org.tweetwallfx.controls.TweetLayout;
 import org.tweetwallfx.controls.Word;
 import org.tweetwallfx.controls.WordleLayout;
 import org.tweetwallfx.controls.WordleSkin;
+import org.tweetwallfx.controls.dataprovider.DataProvider;
 import org.tweetwallfx.controls.dataprovider.TagCloudDataProvider;
 import org.tweetwallfx.controls.stepengine.Step;
 import org.tweetwallfx.controls.stepengine.StepEngine.MachineContext;
@@ -182,6 +185,11 @@ public class TweetToCloudStep implements Step {
         @Override
         public Class<TweetToCloudStep> getStepClass() {
             return TweetToCloudStep.class;
+        }
+
+        @Override
+        public Collection<Class<? extends DataProvider>> getRequiredDataProviders(final StepEngineSettings.StepDefinition stepSettings) {
+            return Arrays.asList(TagCloudDataProvider.class);
         }
     }
 }

--- a/controls/src/main/java/org/tweetwallfx/controls/steps/UpdateCloudStep.java
+++ b/controls/src/main/java/org/tweetwallfx/controls/steps/UpdateCloudStep.java
@@ -24,6 +24,8 @@
 package org.tweetwallfx.controls.steps;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -39,6 +41,7 @@ import org.apache.logging.log4j.Logger;
 import org.tweetwallfx.controls.Word;
 import org.tweetwallfx.controls.WordleLayout;
 import org.tweetwallfx.controls.WordleSkin;
+import org.tweetwallfx.controls.dataprovider.DataProvider;
 import org.tweetwallfx.controls.dataprovider.TagCloudDataProvider;
 import org.tweetwallfx.controls.stepengine.Step;
 import org.tweetwallfx.controls.stepengine.StepEngine.MachineContext;
@@ -178,6 +181,11 @@ public class UpdateCloudStep implements Step {
         @Override
         public Class<UpdateCloudStep> getStepClass() {
             return UpdateCloudStep.class;
+        }
+
+        @Override
+        public Collection<Class<? extends DataProvider>> getRequiredDataProviders(final StepEngineSettings.StepDefinition stepSettings) {
+            return Arrays.asList(TagCloudDataProvider.class);
         }
     }
 }

--- a/devoxx-2017-be/cinema/src/main/java/org/tweetwallfx/devoxx17be/steps/Devoxx17FlipInTweets.java
+++ b/devoxx-2017-be/cinema/src/main/java/org/tweetwallfx/devoxx17be/steps/Devoxx17FlipInTweets.java
@@ -24,6 +24,8 @@
 package org.tweetwallfx.devoxx17be.steps;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import javafx.animation.FadeTransition;
 import javafx.animation.ParallelTransition;
@@ -39,6 +41,7 @@ import javafx.scene.text.Text;
 import javafx.scene.text.TextFlow;
 import javafx.util.Duration;
 import org.tweetwallfx.controls.WordleSkin;
+import org.tweetwallfx.controls.dataprovider.DataProvider;
 import org.tweetwallfx.controls.stepengine.Step;
 import org.tweetwallfx.controls.stepengine.StepEngine.MachineContext;
 import org.tweetwallfx.controls.stepengine.config.StepEngineSettings;
@@ -172,6 +175,11 @@ public class Devoxx17FlipInTweets implements Step {
         @Override
         public Class<Devoxx17FlipInTweets> getStepClass() {
             return Devoxx17FlipInTweets.class;
+        }
+
+        @Override
+        public Collection<Class<? extends DataProvider>> getRequiredDataProviders(final StepEngineSettings.StepDefinition stepSettings) {
+            return Arrays.asList(TweetStreamDataProvider.class);
         }
     }
 }

--- a/devoxx-2017-be/cinema/src/main/java/org/tweetwallfx/devoxx17be/steps/Devoxx17FlipOutScheduleToday.java
+++ b/devoxx-2017-be/cinema/src/main/java/org/tweetwallfx/devoxx17be/steps/Devoxx17FlipOutScheduleToday.java
@@ -23,8 +23,11 @@
  */
 package org.tweetwallfx.devoxx17be.steps;
 
+import java.util.Arrays;
+import java.util.Collection;
 import javafx.scene.Node;
 import org.tweetwallfx.controls.WordleSkin;
+import org.tweetwallfx.controls.dataprovider.DataProvider;
 import org.tweetwallfx.controls.stepengine.Step;
 import org.tweetwallfx.controls.stepengine.StepEngine.MachineContext;
 import org.tweetwallfx.controls.stepengine.config.StepEngineSettings;
@@ -75,6 +78,11 @@ public class Devoxx17FlipOutScheduleToday implements Step {
         @Override
         public Class<Devoxx17FlipOutScheduleToday> getStepClass() {
             return Devoxx17FlipOutScheduleToday.class;
+        }
+
+        @Override
+        public Collection<Class<? extends DataProvider>> getRequiredDataProviders(final StepEngineSettings.StepDefinition stepSettings) {
+            return Arrays.asList(TopTalksTodayDataProvider.class);
         }
     }
 }

--- a/devoxx-2017-be/cinema/src/main/java/org/tweetwallfx/devoxx17be/steps/Devoxx17FlipOutScheduleWeek.java
+++ b/devoxx-2017-be/cinema/src/main/java/org/tweetwallfx/devoxx17be/steps/Devoxx17FlipOutScheduleWeek.java
@@ -23,8 +23,11 @@
  */
 package org.tweetwallfx.devoxx17be.steps;
 
+import java.util.Arrays;
+import java.util.Collection;
 import javafx.scene.Node;
 import org.tweetwallfx.controls.WordleSkin;
+import org.tweetwallfx.controls.dataprovider.DataProvider;
 import org.tweetwallfx.controls.stepengine.Step;
 import org.tweetwallfx.controls.stepengine.StepEngine.MachineContext;
 import org.tweetwallfx.controls.stepengine.config.StepEngineSettings;
@@ -75,6 +78,11 @@ public class Devoxx17FlipOutScheduleWeek implements Step {
         @Override
         public Class<Devoxx17FlipOutScheduleWeek> getStepClass() {
             return Devoxx17FlipOutScheduleWeek.class;
+        }
+
+        @Override
+        public Collection<Class<? extends DataProvider>> getRequiredDataProviders(final StepEngineSettings.StepDefinition stepSettings) {
+            return Arrays.asList(TopTalksWeekDataProvider.class);
         }
     }
 }

--- a/devoxx-2017-be/cinema/src/main/java/org/tweetwallfx/devoxx17be/steps/Devoxx17ShowSchedule.java
+++ b/devoxx-2017-be/cinema/src/main/java/org/tweetwallfx/devoxx17be/steps/Devoxx17ShowSchedule.java
@@ -25,6 +25,8 @@ package org.tweetwallfx.devoxx17be.steps;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -38,6 +40,7 @@ import javafx.scene.text.Text;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.tweetwallfx.controls.WordleSkin;
+import org.tweetwallfx.controls.dataprovider.DataProvider;
 import org.tweetwallfx.controls.stepengine.Step;
 import org.tweetwallfx.controls.stepengine.StepEngine.MachineContext;
 import org.tweetwallfx.controls.stepengine.config.StepEngineSettings;
@@ -130,6 +133,11 @@ public class Devoxx17ShowSchedule extends Devoxx17FlipInTweets {
         @Override
         public Class<Devoxx17ShowSchedule> getStepClass() {
             return Devoxx17ShowSchedule.class;
+        }
+
+        @Override
+        public Collection<Class<? extends DataProvider>> getRequiredDataProviders(final StepEngineSettings.StepDefinition stepSettings) {
+            return Arrays.asList(ScheduleDataProvider.class);
         }
     }
 }

--- a/devoxx-2017-be/cinema/src/main/java/org/tweetwallfx/devoxx17be/steps/Devoxx17ShowTopRatedToday.java
+++ b/devoxx-2017-be/cinema/src/main/java/org/tweetwallfx/devoxx17be/steps/Devoxx17ShowTopRatedToday.java
@@ -25,6 +25,8 @@ package org.tweetwallfx.devoxx17be.steps;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import javafx.animation.ParallelTransition;
@@ -39,6 +41,7 @@ import javafx.scene.text.Text;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.tweetwallfx.controls.WordleSkin;
+import org.tweetwallfx.controls.dataprovider.DataProvider;
 import org.tweetwallfx.controls.stepengine.Step;
 import org.tweetwallfx.controls.stepengine.StepEngine.MachineContext;
 import org.tweetwallfx.controls.stepengine.config.StepEngineSettings;
@@ -142,6 +145,11 @@ public class Devoxx17ShowTopRatedToday implements Step {
         @Override
         public Class<Devoxx17ShowTopRatedToday> getStepClass() {
             return Devoxx17ShowTopRatedToday.class;
+        }
+
+        @Override
+        public Collection<Class<? extends DataProvider>> getRequiredDataProviders(final StepEngineSettings.StepDefinition stepSettings) {
+            return Arrays.asList(TopTalksTodayDataProvider.class);
         }
     }
 }

--- a/devoxx-2017-be/cinema/src/main/java/org/tweetwallfx/devoxx17be/steps/Devoxx17ShowTopRatedWeek.java
+++ b/devoxx-2017-be/cinema/src/main/java/org/tweetwallfx/devoxx17be/steps/Devoxx17ShowTopRatedWeek.java
@@ -25,6 +25,8 @@ package org.tweetwallfx.devoxx17be.steps;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import javafx.animation.ParallelTransition;
@@ -39,6 +41,7 @@ import javafx.scene.text.Text;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.tweetwallfx.controls.WordleSkin;
+import org.tweetwallfx.controls.dataprovider.DataProvider;
 import org.tweetwallfx.controls.stepengine.Step;
 import org.tweetwallfx.controls.stepengine.StepEngine.MachineContext;
 import org.tweetwallfx.controls.stepengine.config.StepEngineSettings;
@@ -142,6 +145,11 @@ public class Devoxx17ShowTopRatedWeek implements Step {
         @Override
         public Class<Devoxx17ShowTopRatedWeek> getStepClass() {
             return Devoxx17ShowTopRatedWeek.class;
+        }
+
+        @Override
+        public Collection<Class<? extends DataProvider>> getRequiredDataProviders(final StepEngineSettings.StepDefinition stepSettings) {
+            return Arrays.asList(TopTalksWeekDataProvider.class);
         }
     }
 }

--- a/devoxx-2017-be/cinema/src/main/java/org/tweetwallfx/devoxx17be/steps/Devoxx17UpdateScheduleResults.java
+++ b/devoxx-2017-be/cinema/src/main/java/org/tweetwallfx/devoxx17be/steps/Devoxx17UpdateScheduleResults.java
@@ -24,6 +24,9 @@
 package org.tweetwallfx.devoxx17be.steps;
 
 import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Collection;
+import org.tweetwallfx.controls.dataprovider.DataProvider;
 import org.tweetwallfx.controls.stepengine.Step;
 import org.tweetwallfx.controls.stepengine.StepEngine.MachineContext;
 import org.tweetwallfx.controls.stepengine.config.StepEngineSettings;
@@ -69,6 +72,11 @@ public class Devoxx17UpdateScheduleResults implements Step {
         @Override
         public Class<Devoxx17UpdateScheduleResults> getStepClass() {
             return Devoxx17UpdateScheduleResults.class;
+        }
+
+        @Override
+        public Collection<Class<? extends DataProvider>> getRequiredDataProviders(final StepEngineSettings.StepDefinition stepSettings) {
+            return Arrays.asList(ScheduleDataProvider.class);
         }
     }
 }

--- a/devoxx-2017-be/cinema/src/main/java/org/tweetwallfx/devoxx17be/steps/Devoxx17UpdateVotingResults.java
+++ b/devoxx-2017-be/cinema/src/main/java/org/tweetwallfx/devoxx17be/steps/Devoxx17UpdateVotingResults.java
@@ -24,6 +24,9 @@
 package org.tweetwallfx.devoxx17be.steps;
 
 import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Collection;
+import org.tweetwallfx.controls.dataprovider.DataProvider;
 import org.tweetwallfx.controls.stepengine.Step;
 import org.tweetwallfx.controls.stepengine.StepEngine.MachineContext;
 import org.tweetwallfx.controls.stepengine.config.StepEngineSettings;
@@ -72,6 +75,11 @@ public class Devoxx17UpdateVotingResults implements Step {
         @Override
         public Class<Devoxx17UpdateVotingResults> getStepClass() {
             return Devoxx17UpdateVotingResults.class;
+        }
+
+        @Override
+        public Collection<Class<? extends DataProvider>> getRequiredDataProviders(final StepEngineSettings.StepDefinition stepSettings) {
+            return Arrays.asList(TopTalksTodayDataProvider.class, TopTalksWeekDataProvider.class);
         }
     }
 }

--- a/devoxx-2017-be/exhibition/src/main/java/org/tweetwallfx/devoxx17be/exhibition/Devoxx17ShowSchedule.java
+++ b/devoxx-2017-be/exhibition/src/main/java/org/tweetwallfx/devoxx17be/exhibition/Devoxx17ShowSchedule.java
@@ -26,6 +26,8 @@ package org.tweetwallfx.devoxx17be.exhibition;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -40,6 +42,7 @@ import javafx.scene.text.Text;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.tweetwallfx.controls.WordleSkin;
+import org.tweetwallfx.controls.dataprovider.DataProvider;
 import org.tweetwallfx.controls.stepengine.Step;
 import org.tweetwallfx.controls.stepengine.StepEngine.MachineContext;
 import org.tweetwallfx.controls.stepengine.config.StepEngineSettings;
@@ -134,6 +137,11 @@ public class Devoxx17ShowSchedule implements Step {
         @Override
         public Class<Devoxx17ShowSchedule> getStepClass() {
             return Devoxx17ShowSchedule.class;
+        }
+
+        @Override
+        public Collection<Class<? extends DataProvider>> getRequiredDataProviders(final StepEngineSettings.StepDefinition stepSettings) {
+            return Arrays.asList(ScheduleDataProvider.class);
         }
     }
 }

--- a/devoxx-2017-be/exhibition/src/main/java/org/tweetwallfx/devoxx17be/exhibition/Devoxx17UpdateScheduleResults.java
+++ b/devoxx-2017-be/exhibition/src/main/java/org/tweetwallfx/devoxx17be/exhibition/Devoxx17UpdateScheduleResults.java
@@ -24,6 +24,9 @@
 package org.tweetwallfx.devoxx17be.exhibition;
 
 import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Collection;
+import org.tweetwallfx.controls.dataprovider.DataProvider;
 import org.tweetwallfx.controls.stepengine.Step;
 import org.tweetwallfx.controls.stepengine.StepEngine.MachineContext;
 import org.tweetwallfx.controls.stepengine.config.StepEngineSettings;
@@ -68,6 +71,11 @@ public class Devoxx17UpdateScheduleResults implements Step {
         @Override
         public Class<Devoxx17UpdateScheduleResults> getStepClass() {
             return Devoxx17UpdateScheduleResults.class;
+        }
+
+        @Override
+        public Collection<Class<? extends DataProvider>> getRequiredDataProviders(final StepEngineSettings.StepDefinition stepSettings) {
+            return Arrays.asList(ScheduleDataProvider.class);
         }
     }
 }


### PR DESCRIPTION
…h allows the declaration of all DataProviders that are required by the Step created by the Factory. By collating these required DataProviders it is possible to only instantiating those required DataProviders and reducing the application overhead.

fixes TweetWallFX/TweetwallFX#350