### PR TITLE
added DataProvider.NewTweetAware which extends from DataProvider (as …

### DIFF
--- a/controls/src/main/java/org/tweetwallfx/controls/dataprovider/DataProvider.java
+++ b/controls/src/main/java/org/tweetwallfx/controls/dataprovider/DataProvider.java
@@ -24,7 +24,6 @@
 package org.tweetwallfx.controls.dataprovider;
 
 import org.tweetwallfx.tweet.api.Tweet;
-import org.tweetwallfx.tweet.api.TweetStream;
 
 /**
  * A Provider of data. The type of data is implementation specific.
@@ -47,29 +46,40 @@ public interface DataProvider {
         Class<? extends DataProvider> getDataProviderClass();
 
         /**
-         * Creates a DataProvider using the provided parameters.
-         *
-         * @param tweetStream A {@link TweetStream}.
+         * Creates a DataProvider.
          *
          * @return the created DataProvider
          */
-        DataProvider create(final TweetStream tweetStream);
+        DataProvider create();
     }
 
     /**
      * Interface enabling call backs for history tweets enabling the build-up of
      * historical data.
      */
-    interface HistoryAware {
+    interface HistoryAware extends DataProvider {
 
         /**
          * Callback to process a historic tweet
          *
          * @param tweet a historic tweet
          */
-        void processTweet(final Tweet tweet);
+        void processHistoryTweet(final Tweet tweet);
     }
 
+    /**
+     * Interface enabling callbacks for receiving newly created tweets.
+     */
+    interface NewTweetAware extends DataProvider {
+        
+        /**
+         * Callback to process a new tweet
+         *
+         * @param tweet a new tweet
+         */
+        void processNewTweet(final Tweet tweet);
+    }
+    
     /**
      * Returns the name of this {@link DataProvider}.
      *

--- a/controls/src/main/java/org/tweetwallfx/controls/dataprovider/ImageMosaicDataProvider.java
+++ b/controls/src/main/java/org/tweetwallfx/controls/dataprovider/ImageMosaicDataProvider.java
@@ -37,7 +37,6 @@ import java.util.concurrent.Executors;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.tweetwallfx.tweet.api.Tweet;
-import org.tweetwallfx.tweet.api.TweetStream;
 
 import javafx.concurrent.Task;
 import javafx.scene.image.Image;
@@ -46,7 +45,7 @@ import org.tweetwallfx.tweet.api.entry.MediaTweetEntryType;
 /**
  * @author Sven Reimers
  */
-public class ImageMosaicDataProvider implements DataProvider, DataProvider.HistoryAware {
+public class ImageMosaicDataProvider implements DataProvider.HistoryAware, DataProvider.NewTweetAware {
 
     private static final Logger LOG = LogManager.getLogger(ImageMosaicDataProvider.class);
     private final MediaCache cache;
@@ -58,13 +57,17 @@ public class ImageMosaicDataProvider implements DataProvider, DataProvider.Histo
     });
     private final List<ImageStore> images = new CopyOnWriteArrayList<>();
 
-    private ImageMosaicDataProvider(final TweetStream tweetStream) {
+    private ImageMosaicDataProvider() {
         cache = MediaCache.INSTANCE;
-        tweetStream.onTweet(tweet -> processTweet(tweet));
     }
 
     @Override
-    public void processTweet(final Tweet tweet) {
+    public void processNewTweet(final Tweet tweet) {
+        processHistoryTweet(tweet);
+    }
+
+    @Override
+    public void processHistoryTweet(final Tweet tweet) {
         LOG.info("new Tweet received");
         if (null == tweet.getMediaEntries() || tweet.isRetweet() || tweet.getUser().getFollowersCount() < 25) {
             return;
@@ -132,8 +135,8 @@ public class ImageMosaicDataProvider implements DataProvider, DataProvider.Histo
     public static class Factory implements DataProvider.Factory {
 
         @Override
-        public ImageMosaicDataProvider create(final TweetStream tweetStream) {
-            return new ImageMosaicDataProvider(tweetStream);
+        public ImageMosaicDataProvider create() {
+            return new ImageMosaicDataProvider();
         }
 
         @Override

--- a/controls/src/main/java/org/tweetwallfx/controls/dataprovider/TagCloudDataProvider.java
+++ b/controls/src/main/java/org/tweetwallfx/controls/dataprovider/TagCloudDataProvider.java
@@ -31,12 +31,11 @@ import java.util.stream.Collectors;
 import org.tweetwallfx.controls.Word;
 import org.tweetwallfx.tweet.StopList;
 import org.tweetwallfx.tweet.api.Tweet;
-import org.tweetwallfx.tweet.api.TweetStream;
 import org.tweetwallfx.tweet.api.entry.MediaTweetEntry;
 import org.tweetwallfx.tweet.api.entry.UrlTweetEntry;
 import org.tweetwallfx.tweet.api.entry.UserMentionTweetEntry;
 
-public class TagCloudDataProvider implements DataProvider, DataProvider.HistoryAware {
+public class TagCloudDataProvider implements DataProvider.HistoryAware, DataProvider.NewTweetAware {
 
     private static final int NUM_MAX_WORDS = 40;
     private static final Comparator<Map.Entry<String, Long>> COMPARATOR = Map.Entry.comparingByValue();
@@ -44,12 +43,17 @@ public class TagCloudDataProvider implements DataProvider, DataProvider.HistoryA
     private List<Word> additionalTweetWords = null;
     private final Map<String, Long> tree = new TreeMap<>();
 
-    private TagCloudDataProvider(final TweetStream tweetStream) {
-        tweetStream.onTweet(tweet -> processTweet(tweet));
+    private TagCloudDataProvider() {
+        // prevent external instantiation
     }
 
     @Override
-    public void processTweet(final Tweet tweet) {
+    public void processNewTweet(final Tweet tweet) {
+        updateTree(tweet);
+    }
+
+    @Override
+    public void processHistoryTweet(final Tweet tweet) {
         updateTree(tweet);
     }
 
@@ -90,8 +94,8 @@ public class TagCloudDataProvider implements DataProvider, DataProvider.HistoryA
     public static class Factory implements DataProvider.Factory {
 
         @Override
-        public TagCloudDataProvider create(TweetStream tweetStream) {
-            return new TagCloudDataProvider(tweetStream);
+        public TagCloudDataProvider create() {
+            return new TagCloudDataProvider();
         }
     
         @Override

--- a/controls/src/main/java/org/tweetwallfx/controls/dataprovider/TweetDataProvider.java
+++ b/controls/src/main/java/org/tweetwallfx/controls/dataprovider/TweetDataProvider.java
@@ -33,10 +33,9 @@ import org.tweetwallfx.config.Configuration;
 import org.tweetwallfx.config.TweetwallSettings;
 import org.tweetwallfx.tweet.api.Tweet;
 import org.tweetwallfx.tweet.api.TweetQuery;
-import org.tweetwallfx.tweet.api.TweetStream;
 import org.tweetwallfx.tweet.api.Tweeter;
 
-public class TweetDataProvider implements DataProvider {
+public class TweetDataProvider implements DataProvider.NewTweetAware {
 
     private static final Logger LOGGER = LogManager.getLogger(TweetDataProvider.class);
     private static final int HISTORY_SIZE = 50;
@@ -47,14 +46,17 @@ public class TweetDataProvider implements DataProvider {
     private final Deque<Long> history = new ArrayDeque<>();
     private volatile List<Tweet> lastTweetCollection;
 
-    private TweetDataProvider(final TweetStream tweetStream) {
-        tweetStream.onTweet(t -> {
-            LOGGER.info("new Tweet received");
-            if (t.getUser().getFollowersCount() > 25) {
-                this.nextTweet = t;
-            }
-            this.lastTweetCollection = null;
-        });
+    private TweetDataProvider() {
+        // prevent external instantiation
+    }
+
+    @Override
+    public void processNewTweet(final Tweet tweet) {
+        LOGGER.info("new Tweet received");
+        if (tweet.getUser().getFollowersCount() > 25) {
+            this.nextTweet = tweet;
+        }
+        this.lastTweetCollection = null;
     }
 
     public Tweet getTweet() {
@@ -102,8 +104,8 @@ public class TweetDataProvider implements DataProvider {
     public static class Factory implements DataProvider.Factory {
 
         @Override
-        public TweetDataProvider create(final TweetStream tweetStream) {
-            return new TweetDataProvider(tweetStream);
+        public TweetDataProvider create() {
+            return new TweetDataProvider();
         }
 
         @Override

--- a/controls/src/main/java/org/tweetwallfx/controls/stepengine/StepEngine.java
+++ b/controls/src/main/java/org/tweetwallfx/controls/stepengine/StepEngine.java
@@ -63,7 +63,6 @@ public final class StepEngine {
     public StepEngine() {
         STARTUP_LOGGER.info("create StepIterator");
         stateIterator = StepIterator.create();
-        STARTUP_LOGGER.info("init DataProviders");
         initDataProviders();
         //initialize every step with context
         stateIterator.applyWith((step) -> step.initStep(context));
@@ -74,28 +73,37 @@ public final class StepEngine {
     }
 
     private void initDataProviders() {
-        STARTUP_LOGGER.info("create TweetStream");
-
+        STARTUP_LOGGER.info("init DataProviders");
         final String searchText = Configuration.getInstance().getConfigTyped(TweetwallSettings.CONFIG_KEY, TweetwallSettings.class).getQuery();
         STARTUP_LOGGER.info("query: " + searchText);
-        final TweetFilterQuery query = new TweetFilterQuery()
-                .track(Pattern.compile(" [oO][rR] ").splitAsStream(searchText).toArray(n -> new String[n]));
-        final TweetStream tweetStream = Tweeter.getInstance().createTweetStream(query);
 
         STARTUP_LOGGER.info("create DataProviders");
         final List<DataProvider> providers = StreamSupport.stream(ServiceLoader.load(DataProvider.Factory.class).spliterator(), false)
-                .map(factory -> factory.create(tweetStream))
+                .map(DataProvider.Factory::create)
                 .peek(dataProvider -> LOG.info("created " + dataProvider))
+                .collect(Collectors.toList());
+        final List<DataProvider.NewTweetAware> newTweetAwareProviders = providers.stream()
+                .filter(DataProvider.NewTweetAware.class::isInstance)
+                .map(DataProvider.NewTweetAware.class::cast)
                 .collect(Collectors.toList());
         final List<DataProvider.HistoryAware> historyAwareProviders = providers.stream()
                 .filter(DataProvider.HistoryAware.class::isInstance)
                 .map(DataProvider.HistoryAware.class::cast)
                 .collect(Collectors.toList());
 
+        if (!newTweetAwareProviders.isEmpty()) {
+            STARTUP_LOGGER.info("create TweetStream");
+            final TweetFilterQuery query = new TweetFilterQuery()
+                    .track(Pattern.compile(" [oO][rR] ").splitAsStream(searchText).toArray(n -> new String[n]));
+            final TweetStream tweetStream = Tweeter.getInstance().createTweetStream(query);
+            
+            newTweetAwareProviders.forEach(ntadp -> tweetStream.onTweet(ntadp::processNewTweet));
+        }
+
         if (!historyAwareProviders.isEmpty()) {
             Tweeter.getInstance()
                     .searchPaged(new TweetQuery().query(searchText).count(100), 20)
-                    .forEach(tweet -> historyAwareProviders.stream().forEach(hap -> hap.processTweet(tweet)));
+                    .forEach(tweet -> historyAwareProviders.stream().forEach(hap -> hap.processHistoryTweet(tweet)));
         }
 
         STARTUP_LOGGER.info("initDataProviders done");

--- a/devoxx-2017-be/cinema/src/main/java/org/tweetwallfx/devoxx2017be/dataprovider/ScheduleDataProvider.java
+++ b/devoxx-2017-be/cinema/src/main/java/org/tweetwallfx/devoxx2017be/dataprovider/ScheduleDataProvider.java
@@ -36,7 +36,6 @@ import org.tweetwall.devoxx.api.cfp.client.CFPClient;
 import org.tweetwall.devoxx.api.cfp.client.Schedule;
 import org.tweetwall.devoxx.api.cfp.client.ScheduleSlot;
 import org.tweetwallfx.controls.dataprovider.DataProvider;
-import org.tweetwallfx.tweet.api.TweetStream;
 
 /**
  * DataProvider Implementation for Schedule Data
@@ -77,7 +76,7 @@ public class ScheduleDataProvider implements DataProvider {
     public static class Factory implements DataProvider.Factory {
 
         @Override
-        public DataProvider create(final TweetStream tweetStream) {
+        public DataProvider create() {
             return new ScheduleDataProvider();
         }
 

--- a/devoxx-2017-be/cinema/src/main/java/org/tweetwallfx/devoxx2017be/dataprovider/TopTalksTodayDataProvider.java
+++ b/devoxx-2017-be/cinema/src/main/java/org/tweetwallfx/devoxx2017be/dataprovider/TopTalksTodayDataProvider.java
@@ -33,7 +33,6 @@ import java.util.stream.Collectors;
 import org.tweetwall.devoxx.api.cfp.client.CFPClient;
 import org.tweetwall.devoxx.api.cfp.client.VotingResultTalk;
 import org.tweetwallfx.controls.dataprovider.DataProvider;
-import org.tweetwallfx.tweet.api.TweetStream;
 
 /**
  * DataProvider Implementation for Top Talks Today
@@ -82,7 +81,7 @@ public final class TopTalksTodayDataProvider implements DataProvider {
     public static class Factory implements DataProvider.Factory {
 
         @Override
-        public TopTalksTodayDataProvider create(final TweetStream tweetStream) {
+        public TopTalksTodayDataProvider create() {
             return new TopTalksTodayDataProvider();
         }
 

--- a/devoxx-2017-be/cinema/src/main/java/org/tweetwallfx/devoxx2017be/dataprovider/TopTalksWeekDataProvider.java
+++ b/devoxx-2017-be/cinema/src/main/java/org/tweetwallfx/devoxx2017be/dataprovider/TopTalksWeekDataProvider.java
@@ -30,7 +30,6 @@ import java.util.stream.Collectors;
 import org.tweetwall.devoxx.api.cfp.client.CFPClient;
 import org.tweetwall.devoxx.api.cfp.client.VotingResultTalk;
 import org.tweetwallfx.controls.dataprovider.DataProvider;
-import org.tweetwallfx.tweet.api.TweetStream;
 
 /**
  * DataProvider Implementation for Top Talks Week
@@ -77,7 +76,7 @@ public final class TopTalksWeekDataProvider implements DataProvider {
     public static class Factory implements DataProvider.Factory {
 
         @Override
-        public TopTalksWeekDataProvider create(TweetStream tweetStream) {
+        public TopTalksWeekDataProvider create() {
             return new TopTalksWeekDataProvider();
         }
 

--- a/devoxx-2017-be/exhibition/src/main/java/org/tweetwallfx/devoxx17be/exhibition/ScheduleDataProvider.java
+++ b/devoxx-2017-be/exhibition/src/main/java/org/tweetwallfx/devoxx17be/exhibition/ScheduleDataProvider.java
@@ -36,7 +36,6 @@ import org.tweetwall.devoxx.api.cfp.client.CFPClient;
 import org.tweetwall.devoxx.api.cfp.client.Schedule;
 import org.tweetwall.devoxx.api.cfp.client.ScheduleSlot;
 import org.tweetwallfx.controls.dataprovider.DataProvider;
-import org.tweetwallfx.tweet.api.TweetStream;
 
 /**
  * DataProvider Implementation for Schedule Data
@@ -48,6 +47,7 @@ public class ScheduleDataProvider implements DataProvider {
     private List<ScheduleSlot> scheduleSlots = Collections.emptyList();
 
     private ScheduleDataProvider() {
+        // prevent external instantiation
     }
 
     public void updateSchedule() {
@@ -77,7 +77,7 @@ public class ScheduleDataProvider implements DataProvider {
     public static class Factory implements DataProvider.Factory {
 
         @Override
-        public ScheduleDataProvider create(final TweetStream tweetStream) {
+        public ScheduleDataProvider create() {
             return new ScheduleDataProvider();
         }
 


### PR DESCRIPTION
…does HistoryAware now too). The interface is used for declaring if a DataProvider will get notified of a newly received tweet. This allows to remove the TweetStream parameter in the DataProvider.Factory.create method as well as only creating the TweetStream in case that any DataProvider.NewTweetAware is required by the StepEngineSettings and its configure Step instances.
Renamed method processTweet in DataProvider.HistoryAware to processHistoryTweet.
fixes TweetWallFX/TweetwallFX#342