### PR TITLE
added DataProviderSetting as a subclass of StepEngineSettings as type…

### DIFF
--- a/controls/src/main/java/org/tweetwallfx/controls/dataprovider/DataProvider.java
+++ b/controls/src/main/java/org/tweetwallfx/controls/dataprovider/DataProvider.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright 2014-2017 TweetWallFX
+ * Copyright 2014-2018 TweetWallFX
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -23,6 +23,7 @@
  */
 package org.tweetwallfx.controls.dataprovider;
 
+import org.tweetwallfx.controls.stepengine.config.StepEngineSettings;
 import org.tweetwallfx.tweet.api.Tweet;
 
 /**
@@ -39,7 +40,7 @@ public interface DataProvider {
 
         /**
          * Returns the class of the Provider this factory will create via
-         * {@link #create(org.tweetwallfx.tweet.api.TweetStream)}.
+         * {@link #create(org.tweetwallfx.controls.stepengine.config.StepEngineSettings.DataProviderSetting)}.
          *
          * @return the class of the Provider this factory will create
          */
@@ -48,9 +49,12 @@ public interface DataProvider {
         /**
          * Creates a DataProvider.
          *
+         * @param dataProviderSetting the settings object for the
+         * {@link DataProvider} about to be created.
+         *
          * @return the created DataProvider
          */
-        DataProvider create();
+        DataProvider create(final StepEngineSettings.DataProviderSetting dataProviderSetting);
     }
 
     /**
@@ -71,7 +75,7 @@ public interface DataProvider {
      * Interface enabling callbacks for receiving newly created tweets.
      */
     interface NewTweetAware extends DataProvider {
-        
+
         /**
          * Callback to process a new tweet
          *
@@ -79,7 +83,7 @@ public interface DataProvider {
          */
         void processNewTweet(final Tweet tweet);
     }
-    
+
     /**
      * Returns the name of this {@link DataProvider}.
      *

--- a/controls/src/main/java/org/tweetwallfx/controls/dataprovider/ImageMosaicDataProvider.java
+++ b/controls/src/main/java/org/tweetwallfx/controls/dataprovider/ImageMosaicDataProvider.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright 2014-2017 TweetWallFX
+ * Copyright 2014-2018 TweetWallFX
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -40,6 +40,7 @@ import org.tweetwallfx.tweet.api.Tweet;
 
 import javafx.concurrent.Task;
 import javafx.scene.image.Image;
+import org.tweetwallfx.controls.stepengine.config.StepEngineSettings;
 import org.tweetwallfx.tweet.api.entry.MediaTweetEntryType;
 
 /**
@@ -135,7 +136,7 @@ public class ImageMosaicDataProvider implements DataProvider.HistoryAware, DataP
     public static class Factory implements DataProvider.Factory {
 
         @Override
-        public ImageMosaicDataProvider create() {
+        public ImageMosaicDataProvider create(final StepEngineSettings.DataProviderSetting dataProviderSetting) {
             return new ImageMosaicDataProvider();
         }
 

--- a/controls/src/main/java/org/tweetwallfx/controls/dataprovider/TagCloudDataProvider.java
+++ b/controls/src/main/java/org/tweetwallfx/controls/dataprovider/TagCloudDataProvider.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright 2014-2017 TweetWallFX
+ * Copyright 2014-2018 TweetWallFX
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -29,6 +29,7 @@ import java.util.Map;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
 import org.tweetwallfx.controls.Word;
+import org.tweetwallfx.controls.stepengine.config.StepEngineSettings;
 import org.tweetwallfx.tweet.StopList;
 import org.tweetwallfx.tweet.api.Tweet;
 import org.tweetwallfx.tweet.api.entry.MediaTweetEntry;
@@ -94,7 +95,7 @@ public class TagCloudDataProvider implements DataProvider.HistoryAware, DataProv
     public static class Factory implements DataProvider.Factory {
 
         @Override
-        public TagCloudDataProvider create() {
+        public TagCloudDataProvider create(final StepEngineSettings.DataProviderSetting dataProviderSetting) {
             return new TagCloudDataProvider();
         }
     

--- a/controls/src/main/java/org/tweetwallfx/controls/dataprovider/TweetDataProvider.java
+++ b/controls/src/main/java/org/tweetwallfx/controls/dataprovider/TweetDataProvider.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright 2014-2017 TweetWallFX
+ * Copyright 2014-2018 TweetWallFX
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -31,6 +31,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.tweetwallfx.config.Configuration;
 import org.tweetwallfx.config.TweetwallSettings;
+import org.tweetwallfx.controls.stepengine.config.StepEngineSettings;
 import org.tweetwallfx.tweet.api.Tweet;
 import org.tweetwallfx.tweet.api.TweetQuery;
 import org.tweetwallfx.tweet.api.Tweeter;
@@ -104,7 +105,7 @@ public class TweetDataProvider implements DataProvider.NewTweetAware {
     public static class Factory implements DataProvider.Factory {
 
         @Override
-        public TweetDataProvider create() {
+        public TweetDataProvider create(final StepEngineSettings.DataProviderSetting dataProviderSetting) {
             return new TweetDataProvider();
         }
 

--- a/controls/src/main/java/org/tweetwallfx/controls/stepengine/config/StepEngineSettings.java
+++ b/controls/src/main/java/org/tweetwallfx/controls/stepengine/config/StepEngineSettings.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright 2014-2017 TweetWallFX
+ * Copyright 2014-2018 TweetWallFX
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -25,12 +25,14 @@ package org.tweetwallfx.controls.stepengine.config;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
-import org.tweetwall.util.JsonDataConverter;
+import org.tweetwall.util.ConfigurableObjectBase;
 import static org.tweetwall.util.ToString.*;
 import org.tweetwallfx.config.ConfigurationConverter;
 import org.tweetwallfx.config.ConnectionSettings;
+import org.tweetwallfx.controls.dataprovider.DataProvider;
+import org.tweetwallfx.controls.stepengine.Step;
+import org.tweetwallfx.controls.stepengine.StepEngine;
 
 /**
  * POJO for reading Settings concerning the HTTP Connection itself.
@@ -43,19 +45,54 @@ public final class StepEngineSettings {
      */
     public static final String CONFIG_KEY = "stepEngine";
     private List<StepDefinition> steps = Collections.emptyList();
+    private List<DataProviderSetting> dataProviderSettings = Collections.emptyList();
 
+    /**
+     * Returns a list containing the definitions for the steps in the
+     * {@link StepEngine}.
+     *
+     * @return a list containing the definitions for the steps in the
+     * {@link StepEngine}
+     */
     public List<StepDefinition> getSteps() {
         return steps;
     }
 
+    /**
+     * Sets a list containing the definitions for the steps in the
+     * {@link StepEngine}.
+     *
+     * @param steps a list containing the definitions for the steps in the
+     * {@link StepEngine}
+     */
     public void setSteps(final List<StepDefinition> steps) {
         Objects.requireNonNull(steps, "steps must not be null!");
         this.steps = steps;
     }
 
+    /**
+     * Returns a list of settings for {@link DataProvider} instances.
+     *
+     * @return a list of settings for {@link DataProvider} instances
+     */
+    public List<DataProviderSetting> getDataProviderSettings() {
+        return dataProviderSettings;
+    }
+
+    /**
+     * Sets a list of settings for {@link DataProvider} instances.
+     *
+     * @param dataProviderSettings a list of settings for {@link DataProvider}
+     * instances
+     */
+    public void setDataProviderSettings(final List<DataProviderSetting> dataProviderSettings) {
+        this.dataProviderSettings = dataProviderSettings;
+    }
+
     @Override
     public String toString() {
         return createToString(this, map(
+                "dataProviderSettings", getDataProviderSettings(),
                 "steps", getSteps()
         )) + " extends " + super.toString();
     }
@@ -77,37 +114,75 @@ public final class StepEngineSettings {
         }
     }
 
-    public static final class StepDefinition {
+    /**
+     * Configurable object containing configuration data (via
+     * {@link #getConfig()} or {@link #getConfig(java.lang.Class)}) for a
+     * {@link Step} instance (identified via {@link #getStepClassName()}.
+     */
+    public static final class StepDefinition extends ConfigurableObjectBase {
 
         private String stepClassName;
-        private Map<String, Object> config;
 
+        /**
+         * Returns the class name of the {@link Step}.
+         *
+         * @return the class name of the {@link Step}
+         */
         public String getStepClassName() {
             return stepClassName;
         }
 
+        /**
+         * Sets the class name of the {@link Step}.
+         *
+         * @param stepClassName the class name of the {@link Step}
+         */
         public void setStepClassName(final String stepClassName) {
             this.stepClassName = stepClassName;
-        }
-
-        public Map<String, Object> getConfig() {
-            return null == config
-                    ? Collections.emptyMap()
-                    : Collections.unmodifiableMap(config);
-        }
-
-        public <T> T getConfig(final Class<T> typeClass) {
-            return JsonDataConverter.convertFromObject(getConfig(), typeClass);
-        }
-
-        public void setConfig(final Map<String, Object> config) {
-            this.config = config;
         }
 
         @Override
         public String toString() {
             return createToString(this, map(
                     "stepClassName", getStepClassName(),
+                    "config", getConfig()
+            )) + " extends " + super.toString();
+        }
+    }
+
+    /**
+     * Configurable object containing configuration data (via
+     * {@link #getConfig()} or {@link #getConfig(java.lang.Class)}) for a
+     * {@link DataProvider} instance (identified via
+     * {@link #getDataProviderClassName()}.
+     */
+    public static class DataProviderSetting extends ConfigurableObjectBase {
+
+        private String dataProviderClassName;
+
+        /**
+         * Returns the class name of the {@link DataProvider}.
+         *
+         * @return the class name of the {@link DataProvider}
+         */
+        public String getDataProviderClassName() {
+            return dataProviderClassName;
+        }
+
+        /**
+         * Sets the class name of the {@link DataProvider}
+         *
+         * @param dataProviderClassName the class name of the
+         * {@link DataProvider}
+         */
+        public void setDataProviderClassName(final String dataProviderClassName) {
+            this.dataProviderClassName = dataProviderClassName;
+        }
+
+        @Override
+        public String toString() {
+            return createToString(this, map(
+                    "dataProviderClassName", getDataProviderClassName(),
                     "config", getConfig()
             )) + " extends " + super.toString();
         }

--- a/devoxx-2017-be/cinema/src/main/java/org/tweetwallfx/devoxx2017be/dataprovider/ScheduleDataProvider.java
+++ b/devoxx-2017-be/cinema/src/main/java/org/tweetwallfx/devoxx2017be/dataprovider/ScheduleDataProvider.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright 2017 TweetWallFX
+ * Copyright 2017-2018 TweetWallFX
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -36,6 +36,7 @@ import org.tweetwall.devoxx.api.cfp.client.CFPClient;
 import org.tweetwall.devoxx.api.cfp.client.Schedule;
 import org.tweetwall.devoxx.api.cfp.client.ScheduleSlot;
 import org.tweetwallfx.controls.dataprovider.DataProvider;
+import org.tweetwallfx.controls.stepengine.config.StepEngineSettings;
 
 /**
  * DataProvider Implementation for Schedule Data
@@ -76,7 +77,7 @@ public class ScheduleDataProvider implements DataProvider {
     public static class Factory implements DataProvider.Factory {
 
         @Override
-        public DataProvider create() {
+        public DataProvider create(final StepEngineSettings.DataProviderSetting dataProviderSetting) {
             return new ScheduleDataProvider();
         }
 

--- a/devoxx-2017-be/cinema/src/main/java/org/tweetwallfx/devoxx2017be/dataprovider/TopTalksTodayDataProvider.java
+++ b/devoxx-2017-be/cinema/src/main/java/org/tweetwallfx/devoxx2017be/dataprovider/TopTalksTodayDataProvider.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright 2017 TweetWallFX
+ * Copyright 2018 TweetWallFX
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -33,6 +33,7 @@ import java.util.stream.Collectors;
 import org.tweetwall.devoxx.api.cfp.client.CFPClient;
 import org.tweetwall.devoxx.api.cfp.client.VotingResultTalk;
 import org.tweetwallfx.controls.dataprovider.DataProvider;
+import org.tweetwallfx.controls.stepengine.config.StepEngineSettings;
 
 /**
  * DataProvider Implementation for Top Talks Today
@@ -81,7 +82,7 @@ public final class TopTalksTodayDataProvider implements DataProvider {
     public static class Factory implements DataProvider.Factory {
 
         @Override
-        public TopTalksTodayDataProvider create() {
+        public TopTalksTodayDataProvider create(final StepEngineSettings.DataProviderSetting dataProviderSetting) {
             return new TopTalksTodayDataProvider();
         }
 

--- a/devoxx-2017-be/cinema/src/main/java/org/tweetwallfx/devoxx2017be/dataprovider/TopTalksWeekDataProvider.java
+++ b/devoxx-2017-be/cinema/src/main/java/org/tweetwallfx/devoxx2017be/dataprovider/TopTalksWeekDataProvider.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright 2017 TweetWallFX
+ * Copyright 2017-2018 TweetWallFX
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -30,6 +30,7 @@ import java.util.stream.Collectors;
 import org.tweetwall.devoxx.api.cfp.client.CFPClient;
 import org.tweetwall.devoxx.api.cfp.client.VotingResultTalk;
 import org.tweetwallfx.controls.dataprovider.DataProvider;
+import org.tweetwallfx.controls.stepengine.config.StepEngineSettings;
 
 /**
  * DataProvider Implementation for Top Talks Week
@@ -76,7 +77,7 @@ public final class TopTalksWeekDataProvider implements DataProvider {
     public static class Factory implements DataProvider.Factory {
 
         @Override
-        public TopTalksWeekDataProvider create() {
+        public TopTalksWeekDataProvider create(final StepEngineSettings.DataProviderSetting dataProviderSetting) {
             return new TopTalksWeekDataProvider();
         }
 

--- a/devoxx-2017-be/cinema/src/main/java/org/tweetwallfx/devoxx2017be/dataprovider/TweetStreamDataProvider.java
+++ b/devoxx-2017-be/cinema/src/main/java/org/tweetwallfx/devoxx2017be/dataprovider/TweetStreamDataProvider.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright 2014-2017 TweetWallFX
+ * Copyright 2014-2018 TweetWallFX
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -39,6 +39,7 @@ import org.apache.logging.log4j.Logger;
 import org.tweetwallfx.config.Configuration;
 import org.tweetwallfx.config.TweetwallSettings;
 import org.tweetwallfx.controls.dataprovider.DataProvider;
+import org.tweetwallfx.controls.stepengine.config.StepEngineSettings;
 import org.tweetwallfx.tweet.api.Tweet;
 import org.tweetwallfx.tweet.api.TweetQuery;
 import org.tweetwallfx.tweet.api.Tweeter;
@@ -155,7 +156,7 @@ public class TweetStreamDataProvider implements DataProvider.NewTweetAware {
     public static class Factory implements DataProvider.Factory {
 
         @Override
-        public TweetStreamDataProvider create() {
+        public TweetStreamDataProvider create(final StepEngineSettings.DataProviderSetting dataProviderSetting) {
             return new TweetStreamDataProvider();
         }
 

--- a/devoxx-2017-be/exhibition/src/main/java/org/tweetwallfx/devoxx17be/exhibition/ScheduleDataProvider.java
+++ b/devoxx-2017-be/exhibition/src/main/java/org/tweetwallfx/devoxx17be/exhibition/ScheduleDataProvider.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright 2017 TweetWallFX
+ * Copyright 2017-2018 TweetWallFX
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -36,6 +36,7 @@ import org.tweetwall.devoxx.api.cfp.client.CFPClient;
 import org.tweetwall.devoxx.api.cfp.client.Schedule;
 import org.tweetwall.devoxx.api.cfp.client.ScheduleSlot;
 import org.tweetwallfx.controls.dataprovider.DataProvider;
+import org.tweetwallfx.controls.stepengine.config.StepEngineSettings;
 
 /**
  * DataProvider Implementation for Schedule Data
@@ -77,7 +78,7 @@ public class ScheduleDataProvider implements DataProvider {
     public static class Factory implements DataProvider.Factory {
 
         @Override
-        public ScheduleDataProvider create() {
+        public ScheduleDataProvider create(final StepEngineSettings.DataProviderSetting dataProviderSetting) {
             return new ScheduleDataProvider();
         }
 

--- a/util/src/main/java/org/tweetwall/util/ConfigurableObjectBase.java
+++ b/util/src/main/java/org/tweetwall/util/ConfigurableObjectBase.java
@@ -1,0 +1,72 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2018 TweetWallFX
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.tweetwall.util;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * Configurable base object with the possibility to get configuration data in
+ * its raw form (via {@link #getConfig()}) or as a type safe object (via
+ * {@link #getConfig(java.lang.Class)}).
+ */
+public abstract class ConfigurableObjectBase {
+
+    private Map<String, Object> config;
+
+    /**
+     * Gets the objects configuration data in its raw form.
+     *
+     * @return the objects configuration data in its raw form
+     */
+    public final Map<String, Object> getConfig() {
+        return null == config
+                ? Collections.emptyMap()
+                : Collections.unmodifiableMap(config);
+    }
+
+    /**
+     * Gets the objects configuration data via a type safe object.
+     *
+     * @param <T> the type of the type safe representation of the configuration
+     * data
+     *
+     * @param typeClass the class of the type safe representation of the
+     * configuration data
+     *
+     * @return the objects configuration data via a type safe object
+     */
+    public final <T> T getConfig(final Class<T> typeClass) {
+        return JsonDataConverter.convertFromObject(getConfig(), typeClass);
+    }
+
+    /**
+     * Sets the objects configuration data.
+     *
+     * @param config the configuration data
+     */
+    public final void setConfig(final Map<String, Object> config) {
+        this.config = config;
+    }
+}

--- a/voxxed-days-zurich/src/main/java/org/tweetwallfx/vdz/dataprovider/ScheduleDataProvider.java
+++ b/voxxed-days-zurich/src/main/java/org/tweetwallfx/vdz/dataprovider/ScheduleDataProvider.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright 2017 TweetWallFX
+ * Copyright 2017-2018 TweetWallFX
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -36,6 +36,7 @@ import org.tweetwall.devoxx.api.cfp.client.ScheduleSlot;
 import org.tweetwallfx.controls.dataprovider.DataProvider;
 
 import javafx.application.Platform;
+import org.tweetwallfx.controls.stepengine.config.StepEngineSettings;
 
 /**
  * DataProvider Implementation for Schedule Data
@@ -80,7 +81,7 @@ public class ScheduleDataProvider implements DataProvider {
     public static class Factory implements DataProvider.Factory {
 
         @Override
-        public DataProvider create() {
+        public DataProvider create(final StepEngineSettings.DataProviderSetting dataProviderSetting) {
             return new ScheduleDataProvider();
         }
 

--- a/voxxed-days-zurich/src/main/java/org/tweetwallfx/vdz/dataprovider/TweetStreamDataProvider.java
+++ b/voxxed-days-zurich/src/main/java/org/tweetwallfx/vdz/dataprovider/TweetStreamDataProvider.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright 2014-2017 TweetWallFX
+ * Copyright 2014-2018 TweetWallFX
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -43,6 +43,7 @@ import org.tweetwallfx.tweet.api.entry.MediaTweetEntryType;
 
 import javafx.application.Platform;
 import javafx.scene.image.Image;
+import org.tweetwallfx.controls.stepengine.config.StepEngineSettings;
 
 /**
  * Provides an always current list of tweets based on the configured query. The history length is
@@ -170,7 +171,7 @@ public class TweetStreamDataProvider implements DataProvider.NewTweetAware {
     public static class Factory implements DataProvider.Factory {
 
         @Override
-        public TweetStreamDataProvider create() {
+        public TweetStreamDataProvider create(final StepEngineSettings.DataProviderSetting dataProviderSetting) {
             return new TweetStreamDataProvider();
         }
 


### PR DESCRIPTION
…-safe configuration type for the configuration of DataProvider instances.

passing DataProviderSetting object to the factory call should one exist.
updated the implementations of DataProvider.Factory to accept the DataProviderSetting object
fixes TweetWallFX/TweetwallFX#374