### PR TITLE
Made CFPClientTests more resistant against initialisation error.

### DIFF
--- a/devoxx-2017-be/cfp-impl/src/test/java/org/tweetwall/devoxx/api/cfp/client/impl2017be/CFPClientTest.java
+++ b/devoxx-2017-be/cfp-impl/src/test/java/org/tweetwall/devoxx/api/cfp/client/impl2017be/CFPClientTest.java
@@ -28,9 +28,11 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import javax.ws.rs.ProcessingException;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import org.apache.logging.log4j.LogManager;
 import org.junit.After;
 import static org.junit.Assert.*;
 import org.junit.Assume;
@@ -54,15 +56,24 @@ import org.tweetwall.devoxx.api.cfp.client.VotingResults;
 
 public class CFPClientTest {
 
-    private static final boolean CFP_REACHABLE = Response.Status.Family.SUCCESSFUL == ClientBuilder.newClient()
-            .target(CFPClientDevoxx2017BE.BASE_URI)
-            .request(MediaType.APPLICATION_JSON)
-            .get()
-            .getStatusInfo()
-            .getFamily();
+    private static final boolean CFP_REACHABLE = isCfpReachable();
 
     @Rule
     public TestName testName = new TestName();
+
+    private static boolean isCfpReachable() {
+        try {
+            return Response.Status.Family.SUCCESSFUL == ClientBuilder.newClient()
+                    .target(CFPClientDevoxx2017BE.BASE_URI)
+                    .request(MediaType.APPLICATION_JSON)
+                    .get()
+                    .getStatusInfo()
+                    .getFamily();
+        } catch (final ProcessingException pe) {
+            LogManager.getLogger(CFPClientTest.class).error(pe, pe);
+            return false;
+        }
+    }
 
     @Before
     public void before() {

--- a/devoxx-2017-be/cfp-impl/src/test/resources/log4j2.xml
+++ b/devoxx-2017-be/cfp-impl/src/test/resources/log4j2.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration>
+    <Appenders>
+        <Console name="STDOUT" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d %-5p [%t] %C{2} (%F:%L) - %m%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="info">
+            <AppenderRef ref="STDOUT"/>
+        </Root>
+    </Loggers>
+</Configuration>
+

--- a/devoxx-api-cfp/src/test/java/org/tweetwall/devoxx/api/cfp/client/CFPClientTest.java
+++ b/devoxx-api-cfp/src/test/java/org/tweetwall/devoxx/api/cfp/client/CFPClientTest.java
@@ -28,9 +28,11 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import javax.ws.rs.ProcessingException;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import org.apache.logging.log4j.LogManager;
 import org.junit.After;
 import static org.junit.Assert.*;
 import org.junit.Assume;
@@ -42,15 +44,24 @@ import org.junit.rules.TestName;
 
 public class CFPClientTest {
 
-    private static final boolean CFP_REACHABLE = Response.Status.Family.SUCCESSFUL == ClientBuilder.newClient()
-            .target(CFPClientTestImpl.BASE_URI)
-            .request(MediaType.APPLICATION_JSON)
-            .get()
-            .getStatusInfo()
-            .getFamily();
+    private static final boolean CFP_REACHABLE = isCfpReachable();
 
     @Rule
     public TestName testName = new TestName();
+
+    private static boolean isCfpReachable() {
+        try {
+            return Response.Status.Family.SUCCESSFUL == ClientBuilder.newClient()
+                    .target(CFPClientTestImpl.BASE_URI)
+                    .request(MediaType.APPLICATION_JSON)
+                    .get()
+                    .getStatusInfo()
+                    .getFamily();
+        } catch (final ProcessingException pe) {
+            LogManager.getLogger(CFPClientTest.class).error(pe, pe);
+            return false;
+        }
+    }
 
     @Before
     public void before() {

--- a/devoxx-api-cfp/src/test/resources/log4j2.xml
+++ b/devoxx-api-cfp/src/test/resources/log4j2.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration>
+    <Appenders>
+        <Console name="STDOUT" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d %-5p [%t] %C{2} (%F:%L) - %m%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="info">
+            <AppenderRef ref="STDOUT"/>
+        </Root>
+    </Loggers>
+</Configuration>
+

--- a/voxxed-days-zurich/src/test/java/org/tweetwallfx/vdz/cfp/CFPClientTest.java
+++ b/voxxed-days-zurich/src/test/java/org/tweetwallfx/vdz/cfp/CFPClientTest.java
@@ -34,9 +34,11 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import javax.ws.rs.ProcessingException;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import org.apache.logging.log4j.LogManager;
 
 import org.junit.After;
 import org.junit.Assume;
@@ -60,15 +62,24 @@ import org.tweetwall.devoxx.api.cfp.client.VotingResults;
 
 public class CFPClientTest {
 
-    private static final boolean CFP_REACHABLE = Response.Status.Family.SUCCESSFUL == ClientBuilder.newClient()
-            .target(CFPClientVDZ18.BASE_URI)
-            .request(MediaType.APPLICATION_JSON)
-            .get()
-            .getStatusInfo()
-            .getFamily();
+    private static final boolean CFP_REACHABLE = isCfpReachable();
 
     @Rule
     public TestName testName = new TestName();
+
+    private static boolean isCfpReachable() {
+        try {
+            return Response.Status.Family.SUCCESSFUL == ClientBuilder.newClient()
+                    .target(CFPClientVDZ18.BASE_URI)
+                    .request(MediaType.APPLICATION_JSON)
+                    .get()
+                    .getStatusInfo()
+                    .getFamily();
+        } catch (final ProcessingException pe) {
+            LogManager.getLogger(CFPClientTest.class).error(pe, pe);
+            return false;
+        }
+    }
 
     @Before
     public void before() {


### PR DESCRIPTION
Changed determination of CFP_REACHABLE to be more resistant against SSLHandshakeException, HostNotFoundException and similar exceptions when trying to contact the CFP API Server. This prevents test failing due to failed initialisation of the test class.
Also added log4j2.json files to configure log4j logging in the tests.