### PR TITLE
Only applying the java plugin removed testng from compile classpath.

### DIFF
--- a/util/build.gradle
+++ b/util/build.gradle
@@ -21,7 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-apply plugin: 'groovy'
+apply plugin: 'java'
 
 dependencies {
     compile group: 'javax.json.bind', name:'javax.json.bind-api', version: versionJavaxJsonBindAPI


### PR DESCRIPTION
fixes TweetWallFX/TweetwallFX#484