### PR TITLE
Using JAX-RS API directly instead of the acumulator of javaee-api8.

### DIFF
--- a/devoxx-api-cfp/build.gradle
+++ b/devoxx-api-cfp/build.gradle
@@ -23,7 +23,7 @@
  */
 
 dependencies {
-    compile group: 'javax', name: 'javaee-api', version: versionJavaEEAPI
+    compile group: 'javax.ws.rs', name: 'javax.ws.rs-api', version: versionJavaxWsRsAPI
     compile group: 'org.apache.logging.log4j', name: 'log4j-api', version: versionLog4j
     compile project(':TweetWallFX-Utility')
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -41,6 +41,7 @@ versionJUnit=4.12
 versionJackson=2.+
 versionJasson=1.0.1
 versionJavaEEAPI=8.0
+versionJavaxWsRsAPI=2.1.1
 versionJavaxJson=1.1.2
 versionJavaxJsonBindAPI=1.0
 versionJersey=2.25


### PR DESCRIPTION
fixes TweetWallFX/TweetwallFX#519