### PR TITLE
Added filter chain subproject and default chain for tweets.

### DIFF
--- a/filterchain/build.gradle
+++ b/filterchain/build.gradle
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright 2017-2018 TweetWallFX
+ * Copyright 2018 TweetWallFX
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,6 +21,9 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
+apply plugin: 'java-library'
+
 dependencies {
-    compile project(':tweetwallfx-filterchain')
+    api project(':tweetwallfx-configuration')
 }

--- a/filterchain/src/main/java/org/tweetwallfx/filterchain/FilterChain.java
+++ b/filterchain/src/main/java/org/tweetwallfx/filterchain/FilterChain.java
@@ -1,0 +1,125 @@
+package org.tweetwallfx.filterchain;
+
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.ServiceLoader;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.tweetwallfx.config.Configuration;
+
+/**
+ * Chain of {@link FilterStep}s each evaluating an object and returning a
+ * (possibly) terminal evaluation result. Upon encountering a terminal
+ * evaluation result the evaluation terminates determines if the evaluated
+ * object is accepted or rejected.
+ *
+ * @param <T> the type of the evaluated object
+ */
+public class FilterChain<T> {
+
+    private static final Logger LOGGER = LogManager.getLogger(FilterChain.class);
+    private static final Map<Class<?>, Map<String, FilterStep.Factory>> FACTORIES = StreamSupport
+            .stream(ServiceLoader.load(FilterStep.Factory.class).spliterator(), false)
+            .peek(fsf
+                    -> LOGGER.info(
+                    "Registering FilterStep.Factory '{}' which creates the FilterStep '{}' for the domain object '{}'",
+                    fsf,
+                    fsf.getFilterStepClass().getCanonicalName(),
+                    fsf.getDomainObjectClass().getCanonicalName()))
+            .collect(Collectors.groupingBy(
+                    FilterStep.Factory::getDomainObjectClass,
+                    Collectors.toMap(
+                            fsf -> fsf.getFilterStepClass().getCanonicalName(),
+                            Function.identity(),
+                            (fsf1, fsf2) -> {
+                                throw new IllegalArgumentException("At most one FilterStep.Factory entry may exist for a FilterStep (uncompliant FilterStep.Factory type: '" + fsf1.getFilterStepClass() + "').");
+                            })));
+    private final List<FilterStep<T>> filterSteps;
+    private final boolean defaultResult;
+
+    private FilterChain(
+            final List<FilterStep<T>> filterSteps,
+            final boolean defaultResult) {
+        this.filterSteps = filterSteps;
+        this.defaultResult = defaultResult;
+    }
+
+    /**
+     * Creates a {@link FilterChain} with the given {@code name} and testing the
+     * provided {@code domainObjectClass} based on what has been configured via
+     * {@link FilterChainSettings}.
+     *
+     * @param <T> the type of the domain object of the {@link FilterChain}
+     *
+     * @param domainObjectClass the domain object class of the
+     * {@link FilterChain}
+     *
+     * @param name the name of the configured {@link FilterChain}
+     *
+     * @return the created {@link FilterChain}
+     */
+    public static <T> FilterChain<T> createFilterChain(final Class<T> domainObjectClass, final String name) {
+        Objects.requireNonNull(domainObjectClass, "domainObjectClass must not be null!");
+        Objects.requireNonNull(name, "name must not be null!");
+        final FilterChainSettings settings = Configuration.getInstance().getConfigTyped(
+                FilterChainSettings.CONFIG_KEY,
+                FilterChainSettings.class);
+
+        final FilterChainSettings.FilterChainDefinition filterChainDefinition = settings.getChains().get(name);
+        Objects.requireNonNull(filterChainDefinition, "FilterChainDefinition with name '" + name + "' does not exist!");
+
+        if (!domainObjectClass.getName().equals(filterChainDefinition.getDomainObjectClassName())) {
+            throw new IllegalStateException("The Class name of the domain objects for FilterChainDefinition with name '"
+                    + name
+                    + "' do not match with requested domainClass (domainClass: '"
+                    + domainObjectClass.getName()
+                    + "'; filterChainDefinition.domainObjectClassName: '"
+                    + filterChainDefinition.getDomainObjectClassName()
+                    + "')");
+        }
+
+        final Map<String, FilterStep.Factory> domainObjectFilterStepFactories = FACTORIES.computeIfAbsent(domainObjectClass, doc -> {
+            throw new NoSuchElementException("No FilterStep.Factory instance exist handling domainObjectClass '" + domainObjectClass.getCanonicalName() + "'.");
+        });
+
+        return new FilterChain<>(
+                filterChainDefinition.getFilterSteps().stream()
+                        .map(fsd
+                                -> Objects.requireNonNull(
+                                domainObjectFilterStepFactories.get(fsd.getStepClassName()),
+                                "FilterStep.Factory for filterStepClassName '" + fsd.getStepClassName() + "' does not exist!")
+                                .create(fsd))
+                        .map(fs -> {
+                            @SuppressWarnings("unchecked")
+                            final FilterStep<T> fs2 = (FilterStep<T>) fs;
+                            return fs2;
+                        })
+                        .collect(Collectors.toList()),
+                filterChainDefinition.getDefaultResult()
+        );
+    }
+
+    /**
+     * Produces a {@link Predicate} based on this FilterChain.
+     *
+     * @return a {@link Predicate} based on this FilterChain
+     */
+    public Predicate<T> asPredicate() {
+        return this::process;
+    }
+
+    private boolean process(final T t) {
+        return filterSteps.stream()
+                .map(fs -> fs.check(t))
+                .filter(FilterStep.Result::isTerminal)
+                .findFirst()
+                .map(FilterStep.Result::isAccepted)
+                .orElse(defaultResult);
+    }
+}

--- a/filterchain/src/main/java/org/tweetwallfx/filterchain/FilterChain.java
+++ b/filterchain/src/main/java/org/tweetwallfx/filterchain/FilterChain.java
@@ -1,3 +1,26 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2018 TweetWallFX
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package org.tweetwallfx.filterchain;
 
 import java.util.List;

--- a/filterchain/src/main/java/org/tweetwallfx/filterchain/FilterChainSettings.java
+++ b/filterchain/src/main/java/org/tweetwallfx/filterchain/FilterChainSettings.java
@@ -1,0 +1,206 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2018 TweetWallFX
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.tweetwallfx.filterchain;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import org.tweetwallfx.config.ConfigurationConverter;
+import org.tweetwallfx.util.ConfigurableObjectBase;
+import static org.tweetwallfx.util.ToString.createToString;
+import static org.tweetwallfx.util.ToString.map;
+
+/**
+ * POJO for reading Settings concerning {@link FilterChain}s.
+ */
+public final class FilterChainSettings {
+
+    /**
+     * Configuration key under which the data for this Settings object is stored
+     * in the configuration data map.
+     */
+    public static final String CONFIG_KEY = "filterchains";
+    private Map<String, FilterChainDefinition> chains = Collections.emptyMap();
+
+    /**
+     * Returns the mapping the the {@link FilterChainDefinition}s to the name of
+     * the defined {@link FilterChain}.
+     *
+     * @return the mapping the the {@link FilterChainDefinition}s to the name of
+     * the defined {@link FilterChain}
+     */
+    public Map<String, FilterChainDefinition> getChains() {
+        return chains;
+    }
+
+    /**
+     * Sets the mapping the the {@link FilterChainDefinition}s to the name of
+     * the defined {@link FilterChain}.
+     *
+     * @param chains the new value
+     */
+    public void setChains(final Map<String, FilterChainDefinition> chains) {
+        Objects.requireNonNull(chains, "chains must not be null!");
+        this.chains = chains;
+    }
+
+    @Override
+    public String toString() {
+        return createToString(this, map(
+                "chains", getChains()
+        ), super.toString());
+    }
+
+    /**
+     * Service implementation converting the configuration data of the root key
+     * {@link FilterChainSettings#CONFIG_KEY} into {@link FilterChainSettings}.
+     */
+    public static final class Converter implements ConfigurationConverter {
+
+        @Override
+        public String getResponsibleKey() {
+            return FilterChainSettings.CONFIG_KEY;
+        }
+
+        @Override
+        public Class<?> getDataClass() {
+            return FilterChainSettings.class;
+        }
+    }
+
+    /**
+     * POJO defining a {@link FilterChain}.
+     */
+    public static class FilterChainDefinition {
+
+        private Boolean defaultResult = null;
+        private List<FilterStepDefinition> filterSteps = Collections.emptyList();
+        private String domainObjectClassName = null;
+
+        /**
+         * Returns a boolean flag determining if the evaluated object are
+         * accepted or rejected should no previous evaluation by the
+         * {@link FilterStep}s have terminated the evaluation.
+         *
+         * @return a boolean flag determining if the evaluated object are
+         * accepted or rejected should no previous evaluation by the
+         * {@link FilterStep}s have terminated the evaluation
+         */
+        public Boolean getDefaultResult() {
+            return defaultResult;
+        }
+
+        /**
+         * Sets a boolean flag determining if the evaluated object are accepted
+         * or rejected should no previous evaluation by the {@link FilterStep}s
+         * have terminated the evaluation.
+         *
+         * @param defaultResult the new value
+         */
+        public void setDefaultResult(final Boolean defaultResult) {
+            this.defaultResult = defaultResult;
+        }
+
+        /**
+         * Returns the class name of the domain object being evaluated.
+         *
+         * @return the class name of the domain object being evaluated
+         */
+        public String getDomainObjectClassName() {
+            return domainObjectClassName;
+        }
+
+        /**
+         * Sets the class name of the domain object being evaluated.
+         *
+         * @param domainObjectClassName the new value
+         */
+        public void setDomainObjectClassName(final String domainObjectClassName) {
+            this.domainObjectClassName = domainObjectClassName;
+        }
+
+        /**
+         * Returns the filter steps contained in the {@link FilterChain}.
+         *
+         * @return the filter steps contained in the {@link FilterChain}
+         */
+        public List<FilterStepDefinition> getFilterSteps() {
+            return filterSteps;
+        }
+
+        /**
+         * Sets the filter steps contained in the {@link FilterChain}.
+         *
+         * @param filterSteps the filter steps
+         */
+        public void setFilterSteps(final List<FilterStepDefinition> filterSteps) {
+            Objects.requireNonNull(filterSteps, "filterSteps must not be null!");
+            this.filterSteps = filterSteps;
+        }
+
+        @Override
+        public String toString() {
+            return createToString(this, map(
+                    "filterSteps", getFilterSteps()
+            ), super.toString());
+        }
+    }
+
+    /**
+     * Configurable object containing configuration data (via
+     * {@link #getConfig()} or {@link #getConfig(java.lang.Class)}) for a
+     * {@link FilterStep} instance (identified via {@link #getStepClassName()}.
+     */
+    public static final class FilterStepDefinition extends ConfigurableObjectBase {
+
+        private String stepClassName;
+
+        /**
+         * Returns the class name of the {@link FilterStep}.
+         *
+         * @return the class name of the {@link FilterStep}
+         */
+        public String getStepClassName() {
+            return stepClassName;
+        }
+
+        /**
+         * Sets the class name of the {@link FilterStep}.
+         *
+         * @param stepClassName the class name of the {@link FilterStep}
+         */
+        public void setStepClassName(final String stepClassName) {
+            this.stepClassName = stepClassName;
+        }
+
+        @Override
+        public String toString() {
+            return createToString(this, map(
+                    "stepClassName", getStepClassName(),
+                    "config", getConfig()
+            ), super.toString());
+        }
+    }
+}

--- a/filterchain/src/main/java/org/tweetwallfx/filterchain/FilterStep.java
+++ b/filterchain/src/main/java/org/tweetwallfx/filterchain/FilterStep.java
@@ -1,3 +1,26 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2018 TweetWallFX
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package org.tweetwallfx.filterchain;
 
 /**

--- a/filterchain/src/main/java/org/tweetwallfx/filterchain/FilterStep.java
+++ b/filterchain/src/main/java/org/tweetwallfx/filterchain/FilterStep.java
@@ -1,0 +1,106 @@
+package org.tweetwallfx.filterchain;
+
+/**
+ * A Step in the filter chain checking for something specific.
+ *
+ * @param <T> the type of the object to check
+ */
+public interface FilterStep<T> {
+
+    /**
+     * Checks the given object and returns a {@link Result} of the evaluation.
+     *
+     * @param t the object to check
+     *
+     * @return the result of the evaluation
+     */
+    Result check(final T t);
+
+    /**
+     * The result of a {@link FilterStep} processing an object.
+     */
+    enum Result {
+
+        /**
+         * No definite answer was determined for the processed object.
+         *
+         * Other {@link FilterStep}s will have to be checked.
+         */
+        NOTHING_DEFINITE(false, true),
+        /**
+         * The processed object was accepted by the {@link FilterStep}.
+         *
+         * No further {@link FilterStep}s will have to be checked.
+         */
+        ACCEPTED(true, true),
+        /**
+         * The processed object was rejected by the {@link FilterStep}.
+         *
+         * No further {@link FilterStep}s will have to be checked.
+         */
+        REJECTED(true, false);
+
+        private final boolean terminal;
+        private final boolean accepted;
+
+        Result(final boolean terminal, final boolean accepted) {
+            this.terminal = terminal;
+            this.accepted = accepted;
+        }
+
+        /**
+         * Returns a boolean indicating if the evaluated object was accepted by
+         * the {@link FilterStep} evaluation. Only applicable for terminal
+         * {@link Result}s.
+         *
+         * @return a boolean indicating if the evaluated object was accepted by
+         * the {@link FilterStep} evaluation
+         */
+        public boolean isAccepted() {
+            return accepted;
+        }
+
+        /**
+         * Returns a boolean flag indicating if this {@link Result} is a
+         * terminal result.
+         *
+         * @return a boolean flag indicating if this {@link Result} is a
+         * terminal result
+         */
+        public boolean isTerminal() {
+            return terminal;
+        }
+    }
+
+    /**
+     * A Factory creating a {@link FilterStep}.
+     */
+    interface Factory {
+
+        /**
+         * Returns the class of the domain object of the FilterStep this factory
+         * will create.
+         *
+         * @return the class of the domain object of the FilterStep this factory
+         * will create
+         */
+        Class<?> getDomainObjectClass();
+
+        /**
+         * Returns the class of the FilterStep this factory will create.
+         *
+         * @return the class of the FilterStep this factory will create
+         */
+        Class<? extends FilterStep<?>> getFilterStepClass();
+
+        /**
+         * Creates a FilterStep.
+         *
+         * @param filterStepDefinition the settings object for which the
+         * FilterStep is to be created
+         *
+         * @return the created FilterStep
+         */
+        FilterStep<?> create(final FilterChainSettings.FilterStepDefinition filterStepDefinition);
+    }
+}

--- a/filterchain/src/main/java/org/tweetwallfx/filterchain/testcase/FilterStepFactoryLoadable.java
+++ b/filterchain/src/main/java/org/tweetwallfx/filterchain/testcase/FilterStepFactoryLoadable.java
@@ -1,0 +1,19 @@
+package org.tweetwallfx.filterchain.testcase;
+
+import java.util.ServiceLoader;
+import org.tweetwallfx.filterchain.FilterStep;
+import org.tweetwallfx.util.testcase.RunnableTestCase;
+
+/**
+ * Testcase checking that all registered {@link FilterStep.Factory} instances
+ * are loadable.
+ */
+public class FilterStepFactoryLoadable implements RunnableTestCase {
+
+    @Override
+    public void execute() throws Exception {
+        for (final FilterStep.Factory o : ServiceLoader.load(FilterStep.Factory.class)) {
+            System.out.println("loaded " + o.getClass());
+        }
+    }
+}

--- a/filterchain/src/main/java/org/tweetwallfx/filterchain/testcase/FilterStepFactoryLoadable.java
+++ b/filterchain/src/main/java/org/tweetwallfx/filterchain/testcase/FilterStepFactoryLoadable.java
@@ -1,3 +1,26 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2018 TweetWallFX
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package org.tweetwallfx.filterchain.testcase;
 
 import java.util.ServiceLoader;

--- a/filterchain/src/main/resources/META-INF/services/org.tweetwallfx.config.ConfigurationConverter
+++ b/filterchain/src/main/resources/META-INF/services/org.tweetwallfx.config.ConfigurationConverter
@@ -1,0 +1,1 @@
+org.tweetwallfx.filterchain.FilterChainSettings$Converter

--- a/filterchain/src/main/resources/META-INF/services/org.tweetwallfx.util.testcase.RunnableTestCase
+++ b/filterchain/src/main/resources/META-INF/services/org.tweetwallfx.util.testcase.RunnableTestCase
@@ -1,0 +1,1 @@
+org.tweetwallfx.filterchain.testcase.FilterStepFactoryLoadable

--- a/settings.gradle
+++ b/settings.gradle
@@ -31,6 +31,8 @@ include ':config'
 project(":config").name = "tweetwallfx-configuration"
 include ':controls'
 project(":controls").name = "tweetwallfx-controls"
+include ':filterchain'
+project(":filterchain").name = "tweetwallfx-filterchain"
 include ':logging'
 project(":logging").name = "tweetwallfx-logging"
 include ':stepengine-api'

--- a/tweet-api/src/main/java/org/tweetwallfx/tweet/api/filter/AcceptFromSenderFilterStep.java
+++ b/tweet-api/src/main/java/org/tweetwallfx/tweet/api/filter/AcceptFromSenderFilterStep.java
@@ -1,0 +1,109 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2018 TweetWallFX
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.tweetwallfx.tweet.api.filter;
+
+import java.util.Collections;
+import java.util.Objects;
+import java.util.Set;
+import org.tweetwallfx.filterchain.FilterChainSettings;
+import org.tweetwallfx.filterchain.FilterStep;
+import org.tweetwallfx.tweet.api.Tweet;
+import org.tweetwallfx.tweet.api.User;
+
+/**
+ * A {@link FilterStep} handling {@link Tweet}s by checking the sending
+ * {@link User} {@link User#getName()}.
+ *
+ * In case {@link User#getName()} is one of the names configured in
+ * {@link Config#getUserHandles()} it is terminally accepted with
+ * {@link Result#ACCEPTED}. Otherwise it is evaluated as
+ * {@link Result#NOTHING_DEFINITE}.
+ */
+public final class AcceptFromSenderFilterStep implements FilterStep<Tweet> {
+
+    private final Config config;
+
+    private AcceptFromSenderFilterStep(final Config config) {
+        this.config = config;
+    }
+
+    @Override
+    public Result check(final Tweet tweet) {
+        return config.getUserHandles().contains(tweet.getUser().getName())
+                ? Result.ACCEPTED
+                : Result.NOTHING_DEFINITE;
+    }
+
+    /**
+     * Implementation of {@link FilterStep.Factory} creating
+     * {@link AcceptFromSenderFilterStep}.
+     */
+    public static final class FactoryImpl implements FilterStep.Factory {
+
+        @Override
+        public Class<Tweet> getDomainObjectClass() {
+            return Tweet.class;
+        }
+
+        @Override
+        public Class<AcceptFromSenderFilterStep> getFilterStepClass() {
+            return AcceptFromSenderFilterStep.class;
+        }
+
+        @Override
+        public AcceptFromSenderFilterStep create(final FilterChainSettings.FilterStepDefinition filterStepDefinition) {
+            return new AcceptFromSenderFilterStep(filterStepDefinition.getConfig(Config.class));
+        }
+    }
+
+    /**
+     * POJO used to configure {@link AcceptFromSenderFilterStep}.
+     */
+    public static final class Config {
+
+        private Set<String> userHandles = Collections.emptySet();
+
+        /**
+         * Returns the handles for the {@link User} for which any {@link Tweet}
+         * send by them is automatically accepted.
+         *
+         * @return the handles for the {@link User} for which any {@link Tweet}
+         * send by them is automatically accepted
+         */
+        public Set<String> getUserHandles() {
+            return userHandles;
+        }
+
+        /**
+         * Sets the handles for the {@link User} for which any {@link Tweet}
+         * send by them is automatically accepted.
+         *
+         * @param userHandles the new value
+         */
+        public void setUserHandles(final Set<String> userHandles) {
+            Objects.requireNonNull(userHandles, "userHandles must not be null!");
+            this.userHandles = userHandles;
+        }
+    }
+}

--- a/tweet-api/src/main/java/org/tweetwallfx/tweet/api/filter/UserMinimumFollwerCountFilterStep.java
+++ b/tweet-api/src/main/java/org/tweetwallfx/tweet/api/filter/UserMinimumFollwerCountFilterStep.java
@@ -1,0 +1,106 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2018 TweetWallFX
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.tweetwallfx.tweet.api.filter;
+
+import java.util.Objects;
+import org.tweetwallfx.filterchain.FilterChainSettings;
+import org.tweetwallfx.filterchain.FilterStep;
+import org.tweetwallfx.tweet.api.Tweet;
+import org.tweetwallfx.tweet.api.User;
+
+/**
+ * A {@link FilterStep} handling {@link Tweet}s by checking the sending
+ * {@link User} {@link User#getFollowersCount()}.
+ *
+ * In case {@link User#getFollowersCount()} is less than the amount configured
+ * in {@link Config#get} it is terminally rejected with {@link Result#REJECTED}.
+ * Otherwise it is evaluated as {@link Result#NOTHING_DEFINITE}.
+ */
+public class UserMinimumFollwerCountFilterStep implements FilterStep<Tweet> {
+
+    private final Config config;
+
+    private UserMinimumFollwerCountFilterStep(final Config config) {
+        this.config = config;
+    }
+
+    @Override
+    public Result check(final Tweet tweet) {
+        return config.getCount() <= tweet.getUser().getFollowersCount()
+                ? Result.NOTHING_DEFINITE
+                : Result.REJECTED;
+    }
+
+    /**
+     * Implementation of {@link FilterStep.Factory} creating
+     * {@link UserMinimumFollwerCountFilterStep}.
+     */
+    public static final class FactoryImpl implements FilterStep.Factory {
+
+        @Override
+        public Class<Tweet> getDomainObjectClass() {
+            return Tweet.class;
+        }
+
+        @Override
+        public Class<UserMinimumFollwerCountFilterStep> getFilterStepClass() {
+            return UserMinimumFollwerCountFilterStep.class;
+        }
+
+        @Override
+        public UserMinimumFollwerCountFilterStep create(final FilterChainSettings.FilterStepDefinition filterStepDefinition) {
+            return new UserMinimumFollwerCountFilterStep(filterStepDefinition.getConfig(Config.class));
+        }
+    }
+
+    /**
+     * POJO used to configure {@link UserMinimumFollwerCountFilterStep}.
+     */
+    public static final class Config {
+
+        private Integer count;
+
+        /**
+         * Returns the number of followers a {@link User} shall have at a
+         * minimum in order to not be terminally rejected.
+         *
+         * @return the number of followers a {@link User} shall have at a
+         * minimum in order to not be terminally rejected
+         */
+        public Integer getCount() {
+            return count;
+        }
+
+        /**
+         * Sets the number of followers a {@link User} shall have at a minimum
+         * in order to not be terminally rejected.
+         *
+         * @param count the new value
+         */
+        public void setUserHandles(final Integer count) {
+            Objects.requireNonNull(count, "count must not be null!");
+            this.count = count;
+        }
+    }
+}

--- a/tweet-api/src/main/resources/META-INF/services/org.tweetwallfx.filterchain.FilterStep$Factory
+++ b/tweet-api/src/main/resources/META-INF/services/org.tweetwallfx.filterchain.FilterStep$Factory
@@ -1,0 +1,2 @@
+org.tweetwallfx.tweet.api.filter.AcceptFromSenderFilterStep$FactoryImpl
+org.tweetwallfx.tweet.api.filter.UserMinimumFollwerCountFilterStep$FactoryImpl

--- a/tweet-impl-twitter4j/src/main/resources/tweetwallConfig.json
+++ b/tweet-impl-twitter4j/src/main/resources/tweetwallConfig.json
@@ -1,0 +1,10 @@
+{
+    "filterchains": {
+        "chains": {
+            "twitter": {
+                "domainObjectClassName": "org.tweetwallfx.tweet.api.Tweet",
+                "defaultResult": true
+            }
+        }
+    }
+}


### PR DESCRIPTION
FilterChain configurations by name with steps allowing indeterminate and determinate evaluation of an object.
Added default accepting filter chain for tweets.

fixes TweetWallFX/TweetwallFX#332