### PR TITLE
Remove oldest image instead of newest in case the stored exceeds the …

### DIFF
--- a/stepengine-dataproviders/src/main/java/org/tweetwallfx/stepengine/dataproviders/ImageMosaicDataProvider.java
+++ b/stepengine-dataproviders/src/main/java/org/tweetwallfx/stepengine/dataproviders/ImageMosaicDataProvider.java
@@ -83,7 +83,7 @@ public class ImageMosaicDataProvider implements DataProvider.HistoryAware, DataP
             }
             if (config.getMaxCacheSize() < images.size()) {
                 images.sort(Comparator.comparing(ImageStore::getInstant));
-                images.remove(images.size() - 1);
+                images.remove(0);
             }
         });
     }


### PR DESCRIPTION
…configured size.

The sort before that line sorts the stored images in natural order by the instant the image was tweeted. Removing the last elements then removes the latest image.
However the newest images should be displayed and thus we remove the first entry from the list.
fixes TweetWallFX/TweetwallFX#679