### PR TITLE
Made direct configuration of DataProviderSetting and FilterStepDefini…

### DIFF
--- a/config/src/main/java/org/tweetwallfx/config/Configuration.java
+++ b/config/src/main/java/org/tweetwallfx/config/Configuration.java
@@ -286,7 +286,7 @@ public final class Configuration {
         ));
     }
 
-    private static Map<String, Object> mergeMap(final Map<String, Object> previous, final Map<String, Object> next) {
+    public static Map<String, Object> mergeMap(final Map<String, Object> previous, final Map<String, Object> next) {
         Objects.requireNonNull(next, "Parameter next must not be null!");
 
         if (null == previous || previous.isEmpty()) {

--- a/filterchain/src/main/java/org/tweetwallfx/filterchain/FilterChainSettings.java
+++ b/filterchain/src/main/java/org/tweetwallfx/filterchain/FilterChainSettings.java
@@ -27,8 +27,10 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import org.tweetwallfx.config.Configuration;
 import org.tweetwallfx.config.ConfigurationConverter;
 import org.tweetwallfx.util.ConfigurableObjectBase;
+import org.tweetwallfx.util.JsonDataConverter;
 import static org.tweetwallfx.util.ToString.createToString;
 import static org.tweetwallfx.util.ToString.map;
 
@@ -172,6 +174,11 @@ public final class FilterChainSettings {
      * Configurable object containing configuration data (via
      * {@link #getConfig()} or {@link #getConfig(java.lang.Class)}) for a
      * {@link FilterStep} instance (identified via {@link #getStepClassName()}.
+     *
+     * <p>
+     * Configuration can be extended by configuring the properties of the
+     * {@code config} section of this definition on the root level of the
+     * Configuration.
      */
     public static final class FilterStepDefinition extends ConfigurableObjectBase {
 
@@ -193,6 +200,14 @@ public final class FilterChainSettings {
          */
         public void setStepClassName(final String stepClassName) {
             this.stepClassName = stepClassName;
+        }
+
+        @Override
+        public <T> T getConfig(final Class<T> typeClass) {
+            @SuppressWarnings("unchecked")
+            final Map<String, Object> specializedConfig = (Map<String, Object>) Configuration.getInstance().getConfig(typeClass.getName(), Collections.emptyMap());
+            final Map<String, Object> mergedConfig = Configuration.mergeMap(getConfig(), specializedConfig);
+            return JsonDataConverter.convertFromObject(mergedConfig, typeClass);
         }
 
         @Override

--- a/stepengine-api/src/main/java/org/tweetwallfx/stepengine/api/config/StepEngineSettings.java
+++ b/stepengine-api/src/main/java/org/tweetwallfx/stepengine/api/config/StepEngineSettings.java
@@ -25,13 +25,16 @@ package org.tweetwallfx.stepengine.api.config;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import org.tweetwallfx.config.Configuration;
 import org.tweetwallfx.config.ConfigurationConverter;
 import org.tweetwallfx.config.ConnectionSettings;
 import org.tweetwallfx.stepengine.api.DataProvider;
 import org.tweetwallfx.stepengine.api.Step;
 import org.tweetwallfx.stepengine.api.StepEngine;
 import org.tweetwallfx.util.ConfigurableObjectBase;
+import org.tweetwallfx.util.JsonDataConverter;
 import static org.tweetwallfx.util.ToString.createToString;
 import static org.tweetwallfx.util.ToString.map;
 
@@ -156,6 +159,11 @@ public final class StepEngineSettings {
      * {@link #getConfig()} or {@link #getConfig(java.lang.Class)}) for a
      * {@link DataProvider} instance (identified via
      * {@link #getDataProviderClassName()}.
+     *
+     * <p>
+     * Configuration can be extended by configuring the properties of the
+     * {@code config} section of this definition on the root level of the
+     * Configuration.
      */
     public static final class DataProviderSetting extends ConfigurableObjectBase {
 
@@ -178,6 +186,14 @@ public final class StepEngineSettings {
          */
         public void setDataProviderClassName(final String dataProviderClassName) {
             this.dataProviderClassName = dataProviderClassName;
+        }
+
+        @Override
+        public <T> T getConfig(final Class<T> typeClass) {
+            @SuppressWarnings("unchecked")
+            final Map<String, Object> specializedConfig = (Map<String, Object>) Configuration.getInstance().getConfig(typeClass.getName(), Collections.emptyMap());
+            final Map<String, Object> mergedConfig = Configuration.mergeMap(getConfig(), specializedConfig);
+            return JsonDataConverter.convertFromObject(mergedConfig, typeClass);
         }
 
         @Override

--- a/util/src/main/java/org/tweetwallfx/util/ConfigurableObjectBase.java
+++ b/util/src/main/java/org/tweetwallfx/util/ConfigurableObjectBase.java
@@ -57,7 +57,7 @@ public abstract class ConfigurableObjectBase {
      *
      * @return the objects configuration data via a type safe object
      */
-    public final <T> T getConfig(final Class<T> typeClass) {
+    public <T> T getConfig(final Class<T> typeClass) {
         return JsonDataConverter.convertFromObject(getConfig(), typeClass);
     }
 


### PR DESCRIPTION
…tion possible.

Made ConfigurableObjectBase.getData(Class) overridable and doing exactly for the listed types.
The overridden methods merge the configuration data for the step (in-place) and reachable via the FQN type name.
fixes TweetWallFX/TweetwallFX#692