### PR TITLE
Include the project name in the project description allowing tools th…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright 2015-2018 TweetWallFX
+ * Copyright 2015-2019 TweetWallFX
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -65,7 +65,7 @@ ext {
 allprojects {
     group = 'org.tweetwallfx'
     version = currentVersion
-    description = 'JavaFX based Tweetwall'
+    description = 'JavaFX based Tweetwall (' + name + ')'
 
     repositories {
         jcenter()


### PR DESCRIPTION
…at depend on the project description (i.e. netbeans 11.0 gradle integration) for display to discern between multiple projects.