### PR TITLE
For Java11 Compatible JDKs configure Test tasks to add javafx modules.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 /*
- * The MIT License
+ * The MIT License (MIT)
  *
- * Copyright 2015-2019 TweetWallFX
+ * Copyright (c) 2015-2019 TweetWallFX
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -58,7 +58,6 @@ ext {
         ('false' != System.getenv('TRAVIS_PULL_REQUEST')) &&
         null != findProperty('BINTRAY_USER') &&
         null != findProperty('BINTRAY_KEY')
-    preJDK11 = System.getProperty('java.version').startsWith('1.8.')
     javaFxPlatform = osdetector.os == 'osx' ? 'mac' : osdetector.os == 'windows' ? 'win' : osdetector.os
 }
 
@@ -131,33 +130,57 @@ allprojects {
         }
 
         javadoc {
-            doFirst {
-                if (preJDK11) return
-                def additionalModules = (configurations.javafx + configurations.jaxb)
-                options.addStringOption('-module-path', additionalModules.asPath)
-                options.addStringOption('-add-modules', 'java.activation,java.xml.bind,javafx.controls,javafx.graphics,javafx.fxml')
+            if (JavaVersion.current().isJava11Compatible()) {
+                afterEvaluate {
+                    def additionalModules = (configurations.javafx + configurations.jaxb)
+                    options.addStringOption('-module-path', additionalModules.asPath)
+                    options.addStringOption('-add-modules', 'java.activation,java.xml.bind,javafx.controls,javafx.graphics,javafx.fxml')
+                }
             }
         }
 
-        compileJava {
-            doFirst {
-                if (preJDK11) return
-                def additionalModules = (configurations.javafx + configurations.jaxb)
-                options.compilerArgs = [
-                        '--module-path', additionalModules.asPath,
-                        '--add-modules', 'java.activation,java.xml.bind,javafx.controls,javafx.graphics,javafx.fxml',
-                        '-Xlint:all', '-Werror', '-proc:none'
-                ]
+        tasks.withType(JavaCompile) {
+            options.compilerArgs.addAll([
+                    '-Xlint:all',
+                    '-Werror',
+                    '-proc:none',
+            ])
+
+            if (JavaVersion.current().isJava11Compatible()) {
+                afterEvaluate {
+                    def additionalModules = (configurations.javafx + configurations.jaxb)
+                    options.compilerArgs.addAll([
+                            '--module-path',
+                            additionalModules.asPath,
+                            '--add-modules',
+                            'java.activation,java.xml.bind,javafx.controls,javafx.graphics,javafx.fxml',
+                    ])
+                }
             }
         }
 
         tasks.withType(JavaExec) {
-            if (preJDK11) return
-            def additionalModules = (configurations.javafx + configurations.jaxb)
-            jvmArgs '--module-path'
-            jvmArgs additionalModules.asPath
-            jvmArgs '--add-modules'
-            jvmArgs 'java.activation,java.xml.bind,javafx.controls,javafx.graphics,javafx.fxml'
+            if (JavaVersion.current().isJava11Compatible()) {
+                afterEvaluate {
+                    def additionalModules = (configurations.javafx + configurations.jaxb)
+                    jvmArgs '--module-path'
+                    jvmArgs additionalModules.asPath
+                    jvmArgs '--add-modules'
+                    jvmArgs 'java.activation,java.xml.bind,javafx.controls,javafx.graphics,javafx.fxml'
+                }
+            }
+        }
+
+        tasks.withType(Test) {
+            if (JavaVersion.current().isJava11Compatible()) {
+                afterEvaluate {
+                    def additionalModules = (configurations.javafx + configurations.jaxb)
+                    jvmArgs '--module-path'
+                    jvmArgs additionalModules.asPath
+                    jvmArgs '--add-modules'
+                    jvmArgs 'java.activation,java.xml.bind,javafx.controls,javafx.graphics,javafx.fxml'
+                }
+            }
         }
 
         check {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,7 +1,7 @@
 /*
- * The MIT License
+ * The MIT License (MIT)
  *
- * Copyright 2015-2018 TweetWallFX
+ * Copyright (c) 2015-2019 TweetWallFX
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -23,10 +23,10 @@
  */
 
 dependencies {
-    if (preJDK11) {
-        compile group: 'de.jensd', name: 'fontawesomefx', version: versionFontawesomefx8
-    } else {
+    if (JavaVersion.current().isJava9Compatible()) {
         compile group: 'de.jensd', name: 'fontawesomefx-fontawesome', version: versionFontawesomefx9
+    } else {
+        compile group: 'de.jensd', name: 'fontawesomefx', version: versionFontawesomefx8
     }
     compile group: 'com.vdurmont', name: 'emoji-java', version: versionEmojiJava
     compile project(':tweetwallfx-tweet-api')


### PR DESCRIPTION
Configure Java11 JavaFX Modules after the project has been evaluated instead of just prior to the tasks execution.
Use Gradle public API way of determining the Java Compatibility
fixes TweetWallFX/TweetwallFX#767