### PR TITLE
 Removed JDK13 compilation from travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,5 @@ matrix:
       jdk: oraclejdk8
     - dist: xenial
       jdk: openjdk11
-    - dist: xenial
-      jdk: openjdk12
-
-#addons:
-#  apt:
-#    packages:
-#      - oracle-java8-installer
+#    - dist: xenial
+#      jdk: openjdk12


### PR DESCRIPTION
The entry will have to be added again when Gradle 6 becomes available.
fixes TweetWallFX/TweetwallFX#863