### PR TITLE
Ensured that travis build matrix contains JDKs 11 and 12 only.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,10 @@ language: java
 
 matrix:
   include:
-    - dist: trusty
-      jdk: oraclejdk8
     - dist: xenial
       jdk: openjdk11
+    - dist: xenial
+      jdk: openjdk12
 #    - dist: xenial
-#      jdk: openjdk12
+#      jdk: openjdk13
+


### PR DESCRIPTION
fixes TweetWallFX/TweetwallFX#868