### PR TITLE
No longer ignore all spotbug errors on certain projects

### DIFF
--- a/2d/build.gradle
+++ b/2d/build.gradle
@@ -27,5 +27,3 @@ dependencies {
     implementation project(':tweetwallfx-configuration')
     implementation project(':tweetwallfx-controls')
 }
-
-tasks.named('spotbugsMain') { ignoreFailures = true }

--- a/build.gradle
+++ b/build.gradle
@@ -237,6 +237,7 @@ allprojects {
             jvmArgs.add getJvmModulePath()
             jvmArgs.add '--add-modules'
             jvmArgs.add getJvmAdditionalModules()
+            excludeFilter = file("${project.rootDir}/spotbugs-exclude.xml")
         }
 
         tasks.withType(com.github.spotbugs.snom.SpotBugsTask) {

--- a/controls/build.gradle
+++ b/controls/build.gradle
@@ -29,5 +29,3 @@ dependencies {
     implementation project(':tweetwallfx-stepengine-dataproviders')
     implementation project(':tweetwallfx-transitions')
 }
-
-tasks.named('spotbugsMain') { ignoreFailures = true }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -31,5 +31,3 @@ dependencies {
     implementation group: 'com.vdurmont', name: 'emoji-java', version: '5.1.1'
     implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.17.2'
 }
-
-tasks.named('spotbugsMain') { ignoreFailures = true }

--- a/devoxx-api-cfp/build.gradle
+++ b/devoxx-api-cfp/build.gradle
@@ -33,5 +33,3 @@ dependencies {
     runtimeOnly group: 'org.glassfish.jersey.media', name: 'jersey-media-json-jackson', version: '3.0.4'
     runtimeOnly group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.13.2'
 }
-
-tasks.named('spotbugsMain') { ignoreFailures = true }

--- a/spotbugs-exclude.xml
+++ b/spotbugs-exclude.xml
@@ -1,0 +1,52 @@
+<!--
+ The MIT License (MIT)
+
+ Copyright (c) 2022 TweetWallFX
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+-->
+<FindBugsFilter>
+    <!-- contains specific exclusions of bug patterns -->
+    <Match>
+        <Or>
+            <Class name="org.tweetwallfx.controls.TweetLayout" />
+            <Class name="org.tweetwallfx.controls.Wordle" />
+            <Class name="org.tweetwallfx.controls.WordleLayout" />
+            <Class name="org.tweetwallfx.controls.WordleSkin" />
+            <Class name="org.tweetwallfx.controls.dataprovider.TagCloudDataProvider" />
+            <Class name="org.tweetwallfx.stepengine.steps.PauseStep$Config" />
+            <Class name="org.tweetwallfx.stepengine.steps.visual.HideAction$Config" />
+            <Class name="org.tweetwallfx.stepengine.steps.visual.ShowAction$Config" />
+            <Class name="org.tweetwallfx.tweet.StringPropertyAppender" />
+            <Package name="org.tweetwallfx.devoxx.api.cfp.client" />
+        </Or>
+        <Bug pattern="EI_EXPOSE_REP" />
+    </Match>
+    <Match>
+        <Or>
+            <Class name="org.tweetwallfx.controls.TweetLayout$Configuration" />
+            <Class name="org.tweetwallfx.controls.WordleLayout$Configuration" />
+            <Class name="org.tweetwallfx.controls.WordleSkin" />
+            <Class name="org.tweetwallfx.controls.dataprovider.TagCloudDataProvider" />
+            <Class name="org.tweetwallfx.twod.TagTweets" />
+            <Package name="org.tweetwallfx.devoxx.api.cfp.client" />
+        </Or>
+        <Bug pattern="EI_EXPOSE_REP2" />
+    </Match>
+</FindBugsFilter>

--- a/stepengine-steps/build.gradle
+++ b/stepengine-steps/build.gradle
@@ -25,5 +25,3 @@
 dependencies {
     implementation project(':tweetwallfx-stepengine-dataproviders')
 }
-
-tasks.named('spotbugsMain') { ignoreFailures = true }


### PR DESCRIPTION
- removed the per project specific complete disabling of sporbugs
- introduced central exclution filter list containing all allowed
  exclutions from the default rule set

Signed-off-by: Patrick Reinhart <patrick@reini.net>