### PR TITLE
🐛 Fix NPE when remote resource load fails

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -111,7 +111,7 @@ allprojects {
         }
     }
 
-    // now configuring for projects that coontain code not just structuring the project
+    // now configuring for projects that contain code not just structuring the project
     if (childProjects.isEmpty()) {
         // configuring standard java project
         apply plugin: 'java-library'
@@ -162,6 +162,9 @@ allprojects {
 
             testFramework group: 'junit', name: 'junit', version: '4.13.2'
             testFramework group: 'org.assertj', name: 'assertj-core', version: '3.23.1'
+            testFramework group: 'org.mockito', name: 'mockito-core', version: '4.6.0'
+
+            testRuntimeOnly group: 'org.mockito', name: 'mockito-inline', version: '4.6.0'
         }
 
         ext {

--- a/cache/src/test/java/org/tweetwallfx/cache/URLContentCacheBaseTest.java
+++ b/cache/src/test/java/org/tweetwallfx/cache/URLContentCacheBaseTest.java
@@ -1,0 +1,105 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2022 TweetWallFX
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.tweetwallfx.cache;
+
+import org.ehcache.Cache;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.io.InputStream;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static org.tweetwallfx.cache.URLContent.NO_CONTENT;
+
+@RunWith(MockitoJUnitRunner.class)
+public class URLContentCacheBaseTest {
+    @Mock
+    private Cache<String, URLContent> urlContentCache;
+    @Mock
+    private ExecutorService contentLoader;
+    @Mock
+    private URLContent cachedValue;
+    private URLContentCacheBase cacheBase;
+
+    @Before
+    public void setUp() {
+        cacheBase = new URLContentCacheBase("test", urlContentCache, contentLoader) {
+        };
+    }
+
+    @Test
+    public void testGetDefault() {
+        try (var cacheManagerProvider = mockStatic(CacheManagerProvider.class);
+             var executors = mockStatic(Executors.class)) {
+            cacheManagerProvider.when(() -> CacheManagerProvider.getCache("default", String.class,
+                    URLContent.class)).thenReturn(urlContentCache);
+            executors.when(() -> Executors.newFixedThreadPool(eq(2), isA(ThreadFactory.class))).thenReturn(contentLoader);
+            assertThat(URLContentCacheBase.getDefault()).isNotNull();
+            verifyNoMoreInteractions(urlContentCache, contentLoader, cachedValue);
+        }
+    }
+
+    @Test
+    public void hasCachedContent() {
+        when(urlContentCache.containsKey("file:///one")).thenReturn(false);
+        when(urlContentCache.containsKey("file:///two")).thenReturn(true);
+        assertThat(cacheBase.hasCachedContent("file:///one")).isFalse();
+        assertThat(cacheBase.hasCachedContent("file:///two")).isTrue();
+    }
+
+    @Test
+    public void getCachedContent() {
+        when(urlContentCache.get("file:///one")).thenReturn(null);
+        when(urlContentCache.get("file:///two")).thenReturn(cachedValue);
+        assertThat(cacheBase.getCachedContent("file:///one")).isEmpty();
+        assertThat(cacheBase.getCachedContent("file:///two")).contains(cachedValue);
+    }
+
+    @Test
+    public void getCachedOrLoad() {
+        when(urlContentCache.get("file:///one")).thenReturn(null);
+        when(urlContentCache.get("file:///two")).thenReturn(cachedValue);
+        assertThat(cacheBase.getCachedOrLoad("file:///one")).isEqualTo(NO_CONTENT);
+        assertThat(cacheBase.getCachedOrLoad("file:///two")).isEqualTo(cachedValue);
+    }
+
+    @Test
+    public void putCachedContent() {
+        cacheBase.putCachedContent("file:///one", InputStream.nullInputStream());
+        verify(urlContentCache).put("file:///one", NO_CONTENT);
+        verifyNoMoreInteractions(urlContentCache, contentLoader, cachedValue);
+    }
+}

--- a/cache/src/test/java/org/tweetwallfx/cache/URLContentTest.java
+++ b/cache/src/test/java/org/tweetwallfx/cache/URLContentTest.java
@@ -1,0 +1,41 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2022 TweetWallFX
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.tweetwallfx.cache;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.tweetwallfx.cache.URLContent.NO_CONTENT;
+
+public class URLContentTest {
+    @Test
+    public void equals() throws IOException {
+        assertThat(NO_CONTENT)
+                .isEqualTo(new URLContent(new byte[0], NO_CONTENT.digest()))
+                .isEqualTo(URLContent.of(InputStream.nullInputStream()));
+    }
+}

--- a/spotbugs-exclude.xml
+++ b/spotbugs-exclude.xml
@@ -27,9 +27,14 @@
         <Or>
             <Class name="org.tweetwallfx.cache.URLContentCacheBase$1" />
             <Class name="org.tweetwallfx.cache.URLContentCacheBase$2" />
+            <Class name="org.tweetwallfx.cache.URLContentCacheBaseTest" />
             <Class name="org.tweetwallfx.stepengine.api.StepEngine" />
         </Or>
         <Bug code="THROWS" />
+    </Match>
+    <Match>
+        <Class name="org.tweetwallfx.cache.URLContentCacheBaseTest" />
+        <Bug code="RCN" />
     </Match>
     <Match>
         <Or>


### PR DESCRIPTION
Fixes that a NPE caused by a not existent resource URL will cause the Tweetwall to hang as found on the Voxxed Day Zurich.