### PR TITLE
🧹 Use compact dependency definitions

### DIFF
--- a/2d/build.gradle
+++ b/2d/build.gradle
@@ -23,7 +23,7 @@
  */
 
 dependencies {
-    implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.17.2'
+    implementation 'org.apache.logging.log4j:log4j-api:2.17.2'
     implementation project(':tweetwallfx-configuration')
     implementation project(':tweetwallfx-controls')
 }

--- a/build.gradle
+++ b/build.gradle
@@ -152,24 +152,24 @@ allprojects {
         }
 
         dependencies {
-            javafx group: 'org.openjfx', name: 'javafx-base', version: '18.0.1', classifier: javaFxPlatform
-            javafx group: 'org.openjfx', name: 'javafx-graphics', version: '18.0.1', classifier: javaFxPlatform
-            javafx group: 'org.openjfx', name: 'javafx-fxml', version: '18.0.1', classifier: javaFxPlatform
-            javafx group: 'org.openjfx', name: 'javafx-controls', version: '18.0.1', classifier: javaFxPlatform
+            javafx 'org.openjfx:javafx-base:18.0.1:' + javaFxPlatform
+            javafx 'org.openjfx:javafx-graphics:18.0.1:' + javaFxPlatform
+            javafx 'org.openjfx:javafx-fxml:18.0.1:' + javaFxPlatform
+            javafx 'org.openjfx:javafx-controls:18.0.1:' + javaFxPlatform
 
-            jaxb group: 'jakarta.activation', name: 'jakarta.activation-api', version: '2.1.0'
-            jaxb group: 'org.eclipse.angus', name: 'angus-activation', version: '1.0.0'
-            jaxb group: 'jakarta.xml.bind', name: 'jakarta.xml.bind-api', version: '4.0.0'
-            jaxb group: 'org.glassfish.jaxb', name: 'jaxb-runtime', version: '4.0.0'
+            jaxb 'jakarta.activation:jakarta.activation-api:2.1.0'
+            jaxb 'org.eclipse.angus:angus-activation:1.0.0'
+            jaxb 'jakarta.xml.bind:jakarta.xml.bind-api:4.0.0'
+            jaxb 'org.glassfish.jaxb:jaxb-runtime:4.0.0'
 
-            testFramework group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: '5.8.2'
-            testFramework group: 'org.junit.jupiter', name: 'junit-jupiter-params', version: '5.8.2'
-            testFramework group: 'org.assertj', name: 'assertj-core', version: '3.23.1'
-            testFramework group: 'org.mockito', name: 'mockito-junit-jupiter', version: '4.6.1'
+            testFramework 'org.junit.jupiter:junit-jupiter-api:5.8.2'
+            testFramework 'org.junit.jupiter:junit-jupiter-params:5.8.2'
+            testFramework 'org.assertj:assertj-core:3.23.1'
+            testFramework 'org.mockito:mockito-junit-jupiter:4.6.1'
 
-            testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: '5.8.2'
-            testRuntimeOnly group: 'org.junit.platform', name: 'junit-platform-runner', version: '1.8.2'
-            testRuntimeOnly group: 'org.mockito', name: 'mockito-inline', version: '4.6.1'
+            testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.2'
+            testRuntimeOnly 'org.junit.platform:junit-platform-runner:1.8.2'
+            testRuntimeOnly 'org.mockito:mockito-inline:4.6.1'
         }
 
         ext {
@@ -244,7 +244,7 @@ allprojects {
         apply plugin: 'net.ltgt.errorprone'
 
         dependencies {
-            errorprone group: 'com.google.errorprone', name: 'error_prone_core', version: '2.14.0'
+            errorprone 'com.google.errorprone:error_prone_core:2.14.0'
         }
 
         // configuring Spotbugs
@@ -291,8 +291,8 @@ allprojects {
 
         plugins.withType(GroovyPlugin) {
             dependencies {
-                implementation group: 'org.codehaus.groovy', name: 'groovy-all', version: '4.0.2'
-                testFramework group: 'org.spockframework', name: 'spock-core', version: '2.1-groovy-3.0'
+                implementation 'org.codehaus.groovy:groovy-all:4.0.2'
+                testFramework 'org.spockframework:spock-core:2.1-groovy-3.0'
             }
         }
 

--- a/cache/build.gradle
+++ b/cache/build.gradle
@@ -23,11 +23,11 @@
  */
 
 dependencies {
-    implementation group: 'com.github.spotbugs', name: 'spotbugs-annotations', version: '4.7.0'
-    implementation group: 'javax.cache', name: 'cache-api', version: '1.1.1'
-    implementation group: 'org.ehcache', name: 'ehcache', version: '3.10.0'
-    implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.17.2'
+    implementation 'com.github.spotbugs:spotbugs-annotations:4.7.0'
+    implementation 'javax.cache:cache-api:1.1.1'
+    implementation 'org.ehcache:ehcache:3.10.0'
+    implementation 'org.apache.logging.log4j:log4j-api:2.17.2'
     implementation project(':tweetwallfx-configuration')
 
-    runtimeOnly group: 'org.apache.logging.log4j', name: 'log4j-slf4j-impl', version: '2.17.2'
+    runtimeOnly 'org.apache.logging.log4j:log4j-slf4j-impl:2.17.2'
 }

--- a/config/build.gradle
+++ b/config/build.gradle
@@ -25,7 +25,7 @@
 dependencies {
     api project(':tweetwallfx-utility')
 
-    implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.17.2'
+    implementation 'org.apache.logging.log4j:log4j-api:2.17.2'
 }
 
 tasks.named('test') {

--- a/controls/build.gradle
+++ b/controls/build.gradle
@@ -23,8 +23,8 @@
  */
 
 dependencies {
-    implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.17.2'
-    implementation group: 'com.github.mfornos', name: 'humanize-slim', version: '1.2.2'
+    implementation 'org.apache.logging.log4j:log4j-api:2.17.2'
+    implementation 'com.github.mfornos:humanize-slim:1.2.2'
     implementation project(':tweetwallfx-core')
     implementation project(':tweetwallfx-stepengine-dataproviders')
     implementation project(':tweetwallfx-transitions')

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -23,11 +23,11 @@
  */
 
 dependencies {
-    api group: 'de.jensd', name: 'fontawesomefx-commons', version: '11.0'
-    api group: 'de.jensd', name: 'fontawesomefx-fontawesome', version: '4.7.0-11'
+    api 'de.jensd:fontawesomefx-commons:11.0'
+    api 'de.jensd:fontawesomefx-fontawesome:4.7.0-11'
     api project(':tweetwallfx-configuration')
     api project(':tweetwallfx-tweet-api')
 
-    implementation group: 'com.vdurmont', name: 'emoji-java', version: '5.1.1'
-    implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.17.2'
+    implementation 'com.vdurmont:emoji-java:5.1.1'
+    implementation 'org.apache.logging.log4j:log4j-core:2.17.2'
 }

--- a/devoxx-api-cfp/build.gradle
+++ b/devoxx-api-cfp/build.gradle
@@ -24,12 +24,12 @@
 
 dependencies {
     api project(':tweetwallfx-utility')
-    api group: 'jakarta.ws.rs', name: 'jakarta.ws.rs-api', version: '3.1.0'
+    api 'jakarta.ws.rs:jakarta.ws.rs-api:3.1.0'
 
-    implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.17.2'
+    implementation 'org.apache.logging.log4j:log4j-api:2.17.2'
 
-    runtimeOnly group: 'org.glassfish.jersey.core', name: 'jersey-client', version: '3.0.4'
-    runtimeOnly group: 'org.glassfish.jersey.inject', name: 'jersey-hk2', version: '3.0.4'
-    runtimeOnly group: 'org.glassfish.jersey.media', name: 'jersey-media-json-jackson', version: '3.0.4'
-    runtimeOnly group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.13.3'
+    runtimeOnly 'org.glassfish.jersey.core:jersey-client:3.0.4'
+    runtimeOnly 'org.glassfish.jersey.inject:jersey-hk2:3.0.4'
+    runtimeOnly 'org.glassfish.jersey.media:jersey-media-json-jackson:3.0.4'
+    runtimeOnly 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.3'
 }

--- a/devoxx-cfp-stepengine/build.gradle
+++ b/devoxx-cfp-stepengine/build.gradle
@@ -22,10 +22,10 @@
  * THE SOFTWARE.
  */
 dependencies {
-    api group: 'de.jensd', name: 'fontawesomefx-commons', version: '11.0'
-    api group: 'de.jensd', name: 'fontawesomefx-fontawesome', version: '4.7.0-11'
+    api 'de.jensd:fontawesomefx-commons:11.0'
+    api 'de.jensd:fontawesomefx-fontawesome:4.7.0-11'
 
-    implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.17.2'
+    implementation 'org.apache.logging.log4j:log4j-api:2.17.2'
     implementation project(':tweetwallfx-controls')
     implementation project(':tweetwallfx-devoxx-api-cfp')
     implementation project(':tweetwallfx-stepengine-dataproviders')

--- a/devoxx-cfp-test/build.gradle
+++ b/devoxx-cfp-test/build.gradle
@@ -26,6 +26,6 @@ configurations {
 }
 
 dependencies {
-    implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.17.2'
+    implementation 'org.apache.logging.log4j:log4j-api:2.17.2'
     implementation project(':tweetwallfx-devoxx-api-cfp')
 }

--- a/filterchain/build.gradle
+++ b/filterchain/build.gradle
@@ -25,5 +25,5 @@
 dependencies {
     api project(':tweetwallfx-configuration')
 
-    implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.17.2'
+    implementation 'org.apache.logging.log4j:log4j-api:2.17.2'
 }

--- a/generic2d/build.gradle
+++ b/generic2d/build.gradle
@@ -23,7 +23,7 @@
  */
 
 dependencies {
-    implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.17.2'
+    implementation 'org.apache.logging.log4j:log4j-core:2.17.2'
     implementation project(':tweetwallfx-2d')
     implementation project(':tweetwallfx-core')
     implementation project(':tweetwallfx-tweet-api')

--- a/google-cloud/build.gradle
+++ b/google-cloud/build.gradle
@@ -23,10 +23,10 @@
  */
 
 dependencies {
-    implementation group: 'com.google.auth', name: 'google-auth-library-oauth2-http', version: '1.7.0'
-    implementation group: 'com.google.cloud', name: 'google-cloud-vision', version: '2.1.1'
-    implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.17.2'
-    implementation group: 'org.ehcache', name: 'ehcache', version: '3.10.0'
+    implementation 'com.google.auth:google-auth-library-oauth2-http:1.7.0'
+    implementation 'com.google.cloud:google-cloud-vision:2.1.1'
+    implementation 'org.apache.logging.log4j:log4j-api:2.17.2'
+    implementation 'org.ehcache:ehcache:3.10.0'
     implementation project(':tweetwallfx-cache')
     implementation project(':tweetwallfx-filterchain')
     implementation project(':tweetwallfx-tweet-api')

--- a/stepengine-api/build.gradle
+++ b/stepengine-api/build.gradle
@@ -26,6 +26,6 @@ dependencies {
     api project(':tweetwallfx-configuration')
     api project(':tweetwallfx-tweet-api')
 
-    implementation group: 'com.github.spotbugs', name: 'spotbugs-annotations', version: '4.7.0'
-    implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.17.2'
+    implementation 'com.github.spotbugs:spotbugs-annotations:4.7.0'
+    implementation 'org.apache.logging.log4j:log4j-api:2.17.2'
 }

--- a/stepengine-dataproviders/build.gradle
+++ b/stepengine-dataproviders/build.gradle
@@ -26,6 +26,6 @@ dependencies {
     api project(':tweetwallfx-cache')
     api project(':tweetwallfx-stepengine-api')
 
-    implementation group: 'com.github.spotbugs', name: 'spotbugs-annotations', version: '4.7.0'
-    implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.17.2'
+    implementation 'com.github.spotbugs:spotbugs-annotations:4.7.0'
+    implementation 'org.apache.logging.log4j:log4j-api:2.17.2'
 }

--- a/tweet-api/build.gradle
+++ b/tweet-api/build.gradle
@@ -22,6 +22,6 @@
  * THE SOFTWARE.
  */
 dependencies {
-    implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.17.2'
+    implementation 'org.apache.logging.log4j:log4j-api:2.17.2'
     implementation project(':tweetwallfx-filterchain')
 }

--- a/tweet-impl-twitter4j/build.gradle
+++ b/tweet-impl-twitter4j/build.gradle
@@ -23,9 +23,9 @@
  */
 
 dependencies {
-    implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.17.2'
-    implementation group: 'org.twitter4j', name: 'twitter4j-core', version: '4.0.7'
-    implementation group: 'org.twitter4j', name: 'twitter4j-stream', version: '4.0.7'
+    implementation 'org.apache.logging.log4j:log4j-api:2.17.2'
+    implementation 'org.twitter4j:twitter4j-core:4.0.7'
+    implementation 'org.twitter4j:twitter4j-stream:4.0.7'
     implementation project(':tweetwallfx-filterchain')
     implementation project(':tweetwallfx-tweet-api')
 }

--- a/util/build.gradle
+++ b/util/build.gradle
@@ -23,6 +23,6 @@
  */
 
 dependencies {
-    implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.17.2'
-    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.13.3'
+    implementation 'org.apache.logging.log4j:log4j-api:2.17.2'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.3'
 }


### PR DESCRIPTION
Use compact dependency declarations instead of verbose ones.