### PR TITLE
Disabled conditional composite build with Mastodon4J.

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -67,7 +67,4 @@ includeWithName ':generic2d', 'tweetwallfx-generic2d'
 // disabled subproject for future reference
 //includeWithName ':3d', 'tweetwallfx-3d'
 
-def mastodon4jProject = new File(rootDir, '../Mastodon4J')
-if (mastodon4jProject.isDirectory()) {
-    includeBuild mastodon4jProject
-}
+//rootProject.file('../Mastodon4J').with{mastodon4jProject -> { if (mastodon4jProject.isDirectory()) includeBuild mastodon4jProject }}


### PR DESCRIPTION
This appears to be necessary as the way it was breaks dependabot evaluation of the root project (Dependabot requires a build.gradle to evaluate your Java dependencies. It had expected to find one at the path: /mastodon4jProject/build.gradle.)