### PR TITLE
Replaced humanize library with prettytime library.

### DIFF
--- a/controls/src/main/java/org/tweetwallfx/controls/steps/InfiniteScrollingTweetsStep.java
+++ b/controls/src/main/java/org/tweetwallfx/controls/steps/InfiniteScrollingTweetsStep.java
@@ -23,7 +23,17 @@
  */
 package org.tweetwallfx.controls.steps;
 
-import humanize.Humanize;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import javafx.animation.FadeTransition;
 import javafx.animation.Interpolator;
 import javafx.animation.Transition;
@@ -41,9 +51,11 @@ import javafx.scene.layout.VBox;
 import javafx.scene.shape.Circle;
 import javafx.scene.shape.Rectangle;
 import javafx.util.Duration;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.tweetwallfx.controls.WordleSkin;
+import org.tweetwallfx.controls.util.TimeFormatter;
 import org.tweetwallfx.emoji.control.EmojiFlow;
 import org.tweetwallfx.stepengine.api.Controllable;
 import org.tweetwallfx.stepengine.api.DataProvider;
@@ -57,19 +69,6 @@ import org.tweetwallfx.transitions.LocationTransition;
 import org.tweetwallfx.tweet.api.Tweet;
 import org.tweetwallfx.tweet.api.entry.MediaTweetEntry;
 import org.tweetwallfx.tweet.api.entry.MediaTweetEntryType;
-
-import java.time.Instant;
-import java.time.ZoneOffset;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Date;
-import java.util.List;
-import java.util.Locale;
-import java.util.Optional;
-import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Infinite TweetStream Animation Step
@@ -273,7 +272,7 @@ public class InfiniteScrollingTweetsStep implements Step, Controllable {
         nameFlow.setCacheHint(config.tweetFlowNode.cacheHint);
 
         Instant createdAt = displayTweet.getCreatedAt().toInstant(ZoneOffset.UTC);
-        Label naturalTime = new Label(Humanize.naturalTime(Date.from(createdAt), Locale.ENGLISH));
+        Label naturalTime = new Label(TimeFormatter.formatNatural(createdAt, Locale.ENGLISH));
         naturalTime.getStyleClass().add("tweetTime");
         naturalTime.setMinWidth(config.tweetWidth);
         naturalTime.setMaxWidth(config.tweetWidth);

--- a/controls/src/main/java/org/tweetwallfx/controls/util/TimeFormatter.java
+++ b/controls/src/main/java/org/tweetwallfx/controls/util/TimeFormatter.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2022 TweetWallFX
+ * Copyright (c) 2023 TweetWallFX
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,15 +21,33 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+package org.tweetwallfx.controls.util;
 
-dependencies {
-    implementation 'org.ocpsoft.prettytime:prettytime:5.0.6.Final'
-    implementation 'de.jensd:fontawesomefx-commons:11.0'
-    implementation 'de.jensd:fontawesomefx-fontawesome:4.7.0-11'
-    implementation 'io.github.encryptorcode:pluralize:1.0.0'
-    implementation 'org.slf4j:slf4j-api'
-    implementation project(':tweetwallfx-core')
-    implementation project(':tweetwallfx-emoji')
-    implementation project(':tweetwallfx-stepengine-dataproviders')
-    implementation project(':tweetwallfx-transitions')
+import java.time.Instant;
+import java.util.Locale;
+
+import org.ocpsoft.prettytime.PrettyTime;
+
+/**
+ * Utility for formatting time
+ */
+public class TimeFormatter {
+
+    private TimeFormatter() {
+    }
+
+    /**
+     * Formats the given {@code date} in natural relative time format (to the
+     * current time) easy to understand by a human (e.g. "3 minutes ago" for
+     * {@code formatNatural(Instant.now().minus(Duration.ofMinutes(3)), Locale.ENGLISH)}.
+     *
+     * @param instant the instant to format
+     *
+     * @param locale the local to use when formatting
+     *
+     * @return the formatted string
+     */
+    public static String formatNatural(Instant instant, Locale locale) {
+        return new PrettyTime(locale).format(instant);
+    }
 }

--- a/controls/src/test/java/org/tweetwallfx/controls/util/TimeFormatterTest.java
+++ b/controls/src/test/java/org/tweetwallfx/controls/util/TimeFormatterTest.java
@@ -1,0 +1,92 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2023 TweetWallFX
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.tweetwallfx.controls.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Date;
+import java.util.Locale;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class TimeFormatterTest {
+
+    static Stream<Arguments> parameters() {
+        return Stream.of(
+                arguments(
+                        Duration.ZERO,
+                        Locale.ENGLISH,
+                        "moments ago"
+                ),
+                arguments(
+                        Duration.ZERO,
+                        Locale.GERMAN,
+                        "gerade eben"
+                ),
+                arguments(
+                        Duration.ofSeconds(10),
+                        Locale.ENGLISH,
+                        "moments ago"
+                ),
+                arguments(
+                        Duration.ofSeconds(30),
+                        Locale.ENGLISH,
+                        "moments ago"
+                ),
+                arguments(
+                        Duration.ofSeconds(55),
+                        Locale.ENGLISH,
+                        "moments ago"
+                ),
+                arguments(
+                        Duration.ofSeconds(187),
+                        Locale.ENGLISH,
+                        "3 minutes ago"
+                ),
+                arguments(
+                        Duration.ofSeconds(307),
+                        Locale.ENGLISH,
+                        "5 minutes ago"
+                ),
+                arguments(
+                        Duration.ofSeconds(607),
+                        Locale.ENGLISH,
+                        "10 minutes ago"
+                )
+        );
+    }
+
+    @ParameterizedTest(name = "{1}: {0} -> {2}")
+    @MethodSource("parameters")
+    public void testFormatNaturalInstant(Duration duration, Locale locale, String expectedFormattedString) {
+        assertThat(TimeFormatter.formatNatural(Instant.now().minus(duration), locale))
+                .isEqualTo(expectedFormattedString);
+    }
+}


### PR DESCRIPTION
This reduces the dependencies to actually used parts of the library and avoids stale library by using maintained one (also used by the stale one). Doing so also avoids
* https://www.cve.org/CVERecord?id=CVE-2018-10237
* https://www.cve.org/CVERecord?id=CVE-2020-8908