### PR TITLE
Skip step if no tweet is available.

### DIFF
--- a/controls/src/main/java/org/tweetwallfx/controls/steps/AddTweetToCloudStep.java
+++ b/controls/src/main/java/org/tweetwallfx/controls/steps/AddTweetToCloudStep.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2022 TweetWallFX
+ * Copyright (c) 2015-2023 TweetWallFX
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -49,6 +49,11 @@ public class AddTweetToCloudStep implements Step {
 
     private AddTweetToCloudStep() {
         // prevent external instantiation
+    }
+
+    @Override
+    public boolean shouldSkip(final MachineContext context) {
+        return null == context.getDataProvider(TweetDataProvider.class).getTweet();
     }
 
     @Override


### PR DESCRIPTION
This prevents NPE when accessing the null tweet.
Implemented based on CloudToTweetStep.