### PR TITLE
Make awaiting initialization of Dataprovider.Scheduled possible

### DIFF
--- a/conference-stepengine/src/main/java/org/tweetwallfx/conference/stepengine/dataprovider/ScheduleDataProvider.java
+++ b/conference-stepengine/src/main/java/org/tweetwallfx/conference/stepengine/dataprovider/ScheduleDataProvider.java
@@ -45,6 +45,7 @@ public class ScheduleDataProvider implements DataProvider, DataProvider.Schedule
 
     private volatile List<ScheduleSlot> scheduleSlots = Collections.emptyList();
     private final Config config;
+    private boolean initialized = false;
 
     private ScheduleDataProvider(final Config config) {
         this.config = config;
@@ -53,6 +54,16 @@ public class ScheduleDataProvider implements DataProvider, DataProvider.Schedule
     @Override
     public ScheduledConfig getScheduleConfig() {
         return config;
+    }
+
+    @Override
+    public boolean requiresInitialization() {
+        return true;
+    }
+
+    @Override
+    public boolean isInitialized() {
+        return initialized;
     }
 
     @Override
@@ -65,6 +76,7 @@ public class ScheduleDataProvider implements DataProvider, DataProvider.Schedule
                                 .getDayOfWeek()
                                 .getDisplayName(TextStyle.FULL, Locale.ENGLISH)
                                 .toLowerCase(Locale.ENGLISH)));
+        initialized = true;
     }
 
     public List<SessionData> getFilteredSessionData() {

--- a/conference-stepengine/src/main/java/org/tweetwallfx/conference/stepengine/dataprovider/TopTalksTodayDataProvider.java
+++ b/conference-stepengine/src/main/java/org/tweetwallfx/conference/stepengine/dataprovider/TopTalksTodayDataProvider.java
@@ -46,6 +46,7 @@ public final class TopTalksTodayDataProvider implements DataProvider, DataProvid
 
     private List<VotedTalk> votedTalks = Collections.emptyList();
     private final Config config;
+    private boolean initialized = false;
 
     private TopTalksTodayDataProvider(final Config config) {
         this.config = config;
@@ -54,6 +55,16 @@ public final class TopTalksTodayDataProvider implements DataProvider, DataProvid
     @Override
     public ScheduledConfig getScheduleConfig() {
         return config;
+    }
+
+    @Override
+    public boolean requiresInitialization() {
+        return true;
+    }
+
+    @Override
+    public boolean isInitialized() {
+        return initialized;
     }
 
     @Override
@@ -72,6 +83,7 @@ public final class TopTalksTodayDataProvider implements DataProvider, DataProvid
                 .limit(config.nrVotes())
                 .map(VotedTalk::new)
                 .toList();
+        initialized = true;
     }
 
     public List<VotedTalk> getFilteredSessionData() {

--- a/conference-stepengine/src/main/java/org/tweetwallfx/conference/stepengine/dataprovider/TopTalksWeekDataProvider.java
+++ b/conference-stepengine/src/main/java/org/tweetwallfx/conference/stepengine/dataprovider/TopTalksWeekDataProvider.java
@@ -42,6 +42,7 @@ public final class TopTalksWeekDataProvider implements DataProvider, DataProvide
 
     private List<VotedTalk> votedTalks = Collections.emptyList();
     private final Config config;
+    private boolean initialized = false;
 
     private TopTalksWeekDataProvider(final Config config) {
         this.config = config;
@@ -50,6 +51,16 @@ public final class TopTalksWeekDataProvider implements DataProvider, DataProvide
     @Override
     public ScheduledConfig getScheduleConfig() {
         return config;
+    }
+
+    @Override
+    public boolean requiresInitialization() {
+        return true;
+    }
+
+    @Override
+    public boolean isInitialized() {
+        return initialized;
     }
 
     @Override
@@ -64,6 +75,7 @@ public final class TopTalksWeekDataProvider implements DataProvider, DataProvide
                 .limit(config.nrVotes())
                 .map(VotedTalk::new)
                 .toList();
+        initialized = true;
     }
 
     public List<VotedTalk> getFilteredSessionData() {

--- a/stepengine-api/src/main/java/org/tweetwallfx/stepengine/api/DataProvider.java
+++ b/stepengine-api/src/main/java/org/tweetwallfx/stepengine/api/DataProvider.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2022 TweetWallFX
+ * Copyright (c) 2016-2023 TweetWallFX
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -95,6 +95,27 @@ public interface DataProvider {
          * @return the configuration defining the periodic scheduled execution
          */
         ScheduledConfig getScheduleConfig();
+
+        /**
+         * {@return a boolean flag indicating that initialization is required prior being utilized}.
+         */
+        default boolean requiresInitialization() {
+            return false;
+        }
+
+        /**
+         * {@return a boolean flag indicating that initialization has been performed}.
+         */
+        default boolean isInitialized() {
+            return false;
+        }
+
+        /**
+         * {@return the number of milli seconds to wait before checking the initialization state again}.
+         */
+        default long initializationCheckIntervallMS() {
+            return 50L;
+        }
     }
 
     /**


### PR DESCRIPTION
This enables displaying a filled list of upcoming sessions when the schedule view is the first view being shown.
Up to now the session data was not yet loaded but the view was being shown regardless.