### PR TITLE
Reactivate buildHealth task invocation

### DIFF
--- a/.github/workflows/dependencyUpdates.yml
+++ b/.github/workflows/dependencyUpdates.yml
@@ -55,7 +55,6 @@ jobs:
 
       # Run dependency-analysis task
       - name: Run dependency-analysis task
-        if: false
         uses: gradle/gradle-build-action@v3.1.0
         with:
           arguments: --no-daemon --refresh-dependencies --scan buildHealth


### PR DESCRIPTION
The `buildHealth` task invocation caused a build failure. See https://github.com/autonomousapps/dependency-analysis-gradle-plugin/issues/908

The task invocation has been disabled in order to get updates of the plugin.

This PR shall undo the disabling of the task invocation.