### PR TITLE
Fixed gradle build action superceeding.

### DIFF
--- a/.github/workflows/dependencyUpdates.yml
+++ b/.github/workflows/dependencyUpdates.yml
@@ -27,10 +27,6 @@ jobs:
       - name: Fetch Sources
         uses: actions/checkout@v4.1.7
 
-      # Validate wrapper
-      - name: Gradle Wrapper Validation
-        uses: gradle/wrapper-validation-action@v3.4.2
-
       # Setup JDK environment for the next steps
       - name: Setup JDK 21
         uses: actions/setup-java@v4.2.1
@@ -39,11 +35,15 @@ jobs:
           java-version: '21'
           cache: gradle
 
+      # Setup gradle
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3.4.2
+        with:
+          validate-wrappers: true
+
       # Run dependencyUpdates task
       - name: Run dependencyUpdates task
-        uses: gradle/gradle-build-action@v3.4.2
-        with:
-          arguments: --no-daemon --refresh-dependencies --scan dependencyUpdates
+        run: ./gradlew --no-daemon --refresh-dependencies --scan dependencyUpdates
 
       # Store dependencyUpdates result files
       - name: Store dependencyUpdates result files
@@ -55,9 +55,7 @@ jobs:
 
       # Run dependency-analysis task
       - name: Run dependency-analysis task
-        uses: gradle/gradle-build-action@v3.4.2
-        with:
-          arguments: --no-daemon --refresh-dependencies --scan buildHealth
+        run: ./gradlew --no-daemon --refresh-dependencies --scan buildHealth
 
       # Store dependency-analysis result files
       - name: Store dependency-analysis result files

--- a/.github/workflows/gradleBuild.yml
+++ b/.github/workflows/gradleBuild.yml
@@ -38,10 +38,6 @@ jobs:
       - name: Fetch Sources
         uses: actions/checkout@v4.1.7
 
-      # Validate wrapper
-      - name: Gradle Wrapper Validation
-        uses: gradle/wrapper-validation-action@v3.4.2
-
       # Setup JDK environment for the next steps
       - name: Setup ${{ matrix.distribution }} JDK ${{ matrix.jdk }} for gradle
         uses: actions/setup-java@v4.2.1
@@ -50,23 +46,23 @@ jobs:
           java-version: ${{ matrix.jdk }}
           cache: gradle
 
+      # Setup gradle
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3.4.2
+        with:
+          validate-wrappers: true
+
       # Run assemble tasks
       - name: Run assemble tasks with toolchain JDK ${{ matrix.jdk }}
-        uses: gradle/gradle-build-action@v3.4.2
-        with:
-          arguments: --no-daemon --refresh-dependencies --scan --warning-mode all --stacktrace assemble
+        run: ./gradlew --no-daemon --refresh-dependencies --scan --warning-mode all --stacktrace assemble
 
       # Run test tasks
       - name: Run test tasks with toolchain JDK ${{ matrix.jdk }}
-        uses: gradle/gradle-build-action@v3.4.2
-        with:
-          arguments: --no-daemon --scan --warning-mode all test
+        run: ./gradlew --no-daemon --scan --warning-mode all test
 
       # Run check tasks
       - name: Run check tasks with toolchain JDK ${{ matrix.jdk }}
-        uses: gradle/gradle-build-action@v3.4.2
-        with:
-          arguments: --no-daemon --scan --warning-mode all check
+        run: ./gradlew --no-daemon --scan --warning-mode all check
 
       # Archive test reports
       - name: Archive build logs
@@ -83,8 +79,6 @@ jobs:
       # Run publish task
       - name: Run publish task
         if: ${{ (matrix.jdk == '17') && (github.event_name == 'push') && success() }}
-        uses: gradle/gradle-build-action@v3.4.2
-        with:
-          arguments: --no-daemon --scan --warning-mode all publish
+        run: ./gradlew --no-daemon --scan --warning-mode all publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
```
This job uses deprecated functionality from the 'gradle/wrapper-validation-action' action. Consult the logs for more details.
This job uses deprecated functionality from the 'gradle/gradle-build-action' action. Consult the Job Summary for more details.
```

and from the release note of gradle-build-action (https://github.com/gradle/gradle-build-action/releases/tag/v3.4.2):
```
As of v3 this action has been superceded by gradle/actions/setup-gradle.
Any workflow that uses gradle/gradle-build-action@v3 will transparently delegate to gradle/actions/setup-gradle@v3.

Users are encouraged to update their workflows, replacing:

uses: gradle/gradle-build-action@v3

with

uses: gradle/actions/setup-gradle@v3

See the setup-gradle documentation for up-to-date documentation for gradle/actions/setup-gradle.
```