### PR TITLE
Added generic ImageStorage and associated DataProvider caching it.

### DIFF
--- a/stepengine-dataproviders/src/main/java/org/tweetwallfx/stepengine/dataproviders/ImageStorage.java
+++ b/stepengine-dataproviders/src/main/java/org/tweetwallfx/stepengine/dataproviders/ImageStorage.java
@@ -1,0 +1,240 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2024 TweetWallFX
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.tweetwallfx.stepengine.dataproviders;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.io.InputStream;
+import java.time.Instant;
+import java.util.Comparator;
+import java.util.Map;
+import java.util.Objects;
+import javafx.scene.image.Image;
+import org.tweetwallfx.cache.URLContent;
+import org.tweetwallfx.config.Configuration;
+import org.tweetwallfx.util.Nullable;
+import org.tweetwallfx.util.ToString;
+
+/**
+ * Storage of a timestamped, optionally categorized, {@link Image} based on
+ * binary data.
+ */
+public final class ImageStorage {
+
+    /**
+     * Key name for the category value in {@link #getAdditionalInfo()}.
+     */
+    public static final String KEY_CATEGORY = "category";
+
+    /**
+     * Default category value.
+     */
+    public static final String DEFAULT_CATEGORY = "DEFAULT";
+
+    /**
+     * Comparator sorting the {@link ImageStorage} instances based on the
+     * natural sorting of their {@link #getTimestamp() timestamp} values.
+     */
+    public static final Comparator<ImageStorage> BY_TIMESTAMP = Comparator
+            .comparing(ImageStorage::getTimestamp);
+
+    private final Instant timestamp;
+    private final Image image;
+    private final String digest;
+    private final Map<String, Object> additionalInfo;
+
+    /**
+     * Creates an ImageStorage instance based on the given parameters.
+     *
+     * @param builder the builder containing the required data for the instance
+     * creation
+     */
+    private ImageStorage(final Builder builder) {
+        this.timestamp = Objects.requireNonNull(builder.timestamp, "timestamp must not be null");
+        this.image = new Image(Objects.requireNonNull(builder.inputStream, "inputStream must not be null"));
+        this.digest = Objects.requireNonNull(builder.digest, "digest must not be null");
+        this.additionalInfo = builder.additionalInfo;
+    }
+
+    /**
+     * Returns the timestamp associated with the {@link Image}.
+     *
+     * @return the timestamp
+     */
+    public Instant getTimestamp() {
+        return timestamp;
+    }
+
+    /**
+     * Returns the {@link Image}.
+     *
+     * @return the {@link Image}
+     */
+    @SuppressFBWarnings
+    public Image getImage() {
+        return image;
+    }
+
+    /**
+     * Returns the additional infos for this {@link ImageStorage} instance.
+     *
+     * @return the additional infos
+     */
+    public Map<String, Object> getAdditionalInfo() {
+        return Nullable.nullable(additionalInfo);
+    }
+
+    /**
+     * Returns the category of this storage. The value is retrieved from
+     * {@link #getAdditionalInfo()} via the key {@link #KEY_CATEGORY}. If none
+     * is present then {@link #DEFAULT_CATEGORY} is returned.
+     *
+     * @return the category
+     */
+    @SuppressWarnings("unchecked")
+    public String getCategory() {
+        return (String) additionalInfo.getOrDefault(KEY_CATEGORY, DEFAULT_CATEGORY);
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 5;
+        hash = 97 * hash + Objects.hashCode(getTimestamp());
+        hash = 97 * hash + Objects.hashCode(digest);
+        return hash;
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        return obj instanceof ImageStorage other
+                && Objects.equals(this.getTimestamp(), other.getTimestamp())
+                && Objects.equals(this.digest, other.digest);
+    }
+
+    @Override
+    public String toString() {
+        return ToString.createToString(
+                this,
+                Map.of(
+                        "timestamp", getTimestamp(),
+                        "digest", digest,
+                        "additionalInfo", getAdditionalInfo()
+                ),
+                true);
+    }
+
+    /**
+     * Creates a new instance of {@link Builder} using the required
+     * {@code timestamp} parameter as a starting value.
+     *
+     * @param timestamp the timestamp associated with the image
+     *
+     * @return the created {@link Builder}
+     */
+    public static Builder builder(final Instant timestamp) {
+        return new Builder(timestamp);
+    }
+
+    /**
+     * A builder of {@link ImageStorage} instances.
+     */
+    public static final class Builder {
+
+        private final Instant timestamp;
+        private InputStream inputStream;
+        private String digest;
+        private Map<String, Object> additionalInfo = Map.of();
+
+        private Builder(final Instant timestamp) {
+            this.timestamp = Objects.requireNonNull(timestamp, "timestamp must not be null");
+        }
+
+        /**
+         * Uses the current state of this {@link Builder} instance to create a
+         * new instance of {@link ImageStorage}
+         *
+         * @return the created {@link ImageStorage} instance
+         */
+        public ImageStorage build() {
+            return new ImageStorage(this);
+        }
+
+        /**
+         * Configures the image data source to be the given {@code inputStream}.
+         *
+         * @param inputStream the image data source
+         *
+         * @return this builder instance
+         */
+        public Builder from(final InputStream inputStream) {
+            this.inputStream = Objects.requireNonNull(inputStream, "inputStream must not be null");
+            return this;
+        }
+
+        /**
+         * Uses the {@link URLContent} to configures the
+         * {@link #from(java.io.InputStream) image data source} and the
+         * {@link #withDigest(java.lang.String) digest} using
+         * {@link URLContent#getInputStream()} and {@link URLContent#digest()}
+         * respectifely.
+         *
+         * @param urlc the {@link URLContent}
+         *
+         * @return this builder instance
+         */
+        public Builder from(final URLContent urlc) {
+            return from(urlc.getInputStream())
+                    .withDigest(urlc.digest());
+        }
+
+        /**
+         * Configures the additional infos for the {@link ImageStorage}
+         * instance.
+         *
+         * @param additionalInfo the additional info
+         *
+         * @return this builder instance
+         */
+        @SuppressWarnings("unchecked")
+        public Builder withAdditionalInfo(final Map<String, Object> additionalInfo) {
+            this.additionalInfo = Configuration.mergeMap(
+                    // ensure category is set to defazlt value
+                    Map.of(KEY_CATEGORY, DEFAULT_CATEGORY),
+                    // possibly overwrite it with the additionalInfo parameter
+                    Nullable.nullable(additionalInfo));
+            return this;
+        }
+
+        /**
+         * Configures the digest of the image data source.
+         *
+         * @param digest the digest
+         *
+         * @return this builder instance
+         */
+        public Builder withDigest(final String digest) {
+            this.digest = digest;
+            return this;
+        }
+    }
+}

--- a/stepengine-dataproviders/src/main/java/org/tweetwallfx/stepengine/dataproviders/ImageStorageDataProvider.java
+++ b/stepengine-dataproviders/src/main/java/org/tweetwallfx/stepengine/dataproviders/ImageStorageDataProvider.java
@@ -1,0 +1,202 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2024 TweetWallFX
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.tweetwallfx.stepengine.dataproviders;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.SequencedSet;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentSkipListSet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.tweetwallfx.cache.URLContent;
+import org.tweetwallfx.stepengine.api.DataProvider;
+
+/**
+ * DataProvider handling {@link ImageStorage} instances of possibly multiple
+ * types.
+ */
+public interface ImageStorageDataProvider extends DataProvider {
+
+    /**
+     * Adds a new {@link ImageStorage} created with the given values.
+     *
+     * @param uc the {@link URLContent} containing the image data
+     *
+     * @param instant the time associated with the image (i.e. the time the
+     * image was posted)
+     *
+     * @param additionalInfo additional info for the stored image
+     */
+    default void add(final URLContent uc, final Instant instant, final Map<String, Object> additionalInfo) {
+        add(ImageStorage.builder(instant).from(uc).withAdditionalInfo(additionalInfo).build());
+    }
+
+    /**
+     * Adds a new {@link ImageStorage} created with the given values.
+     *
+     * @param uc the {@link URLContent} containing the image data
+     *
+     * @param instant the time associated with the image (i.e. the time the
+     * image was posted)
+     */
+    default void add(final URLContent uc, final Instant instant) {
+        add(uc, instant, Map.of());
+    }
+
+    /**
+     * Adds the given {@link ImageStorage} to the internal storage.
+     *
+     * @param imageStorage the new entry
+     */
+    void add(final ImageStorage imageStorage);
+
+    /**
+     * Returns the {@link Access} for the default category
+     * ({@link ImageStorage#DEFAULT_CATEGORY}).
+     *
+     * @return the {@link Access}
+     */
+    default Access getAccess() {
+        return getAccess(ImageStorage.DEFAULT_CATEGORY);
+    }
+
+    /**
+     * Returns the {@link Access} for the requested category.
+     *
+     * @param category the category to access
+     *
+     * @return the {@link Access}
+     */
+    Access getAccess(final String category);
+
+    /**
+     * Data retriever of stored image data.
+     */
+    static interface Access {
+
+        /**
+         * Provides the count of stored images currently available in this data
+         * provider.
+         *
+         * @return the count of stored images
+         */
+        int count();
+
+        /**
+         * Produces a list of the first {@code maxCount} stored images.
+         *
+         * The produced list will contain at most {@code maxCount} stored
+         * images. In case more stored images are available than have been
+         * requested then the first {@code maxCount} will be returned. When
+         * there are fewer stored images than those available ones will be
+         * returned.
+         *
+         * @param maxCount the maximum count of stored images to return (based
+         * on availability)
+         *
+         * @return the produced list
+         */
+        List<ImageStorage> getImages(final int maxCount);
+    }
+
+    /**
+     * Opinionated base implementation of ImageStorageDataProvider missing the
+     * code determining of what data to load. This may e.g. be the content of
+     * the MediaEntry elements of a Twitter message (i.e. the image posted via
+     * the Twitter message).
+     */
+    static abstract class Base implements ImageStorageDataProvider {
+
+        private static final Logger LOG = LoggerFactory.getLogger(Base.class);
+        private final Map<String, SequencedSet<ImageStorage>> categorizedImageStorages = new ConcurrentHashMap<>();
+        private final int maxCacheSize;
+
+        /**
+         * Creates a new instance with the given parameters.
+         *
+         * @param maxCacheSize the maximum number of entries being kept by
+         */
+        protected Base(final int maxCacheSize) {
+            this.maxCacheSize = maxCacheSize;
+        }
+
+        @Override
+        public final void add(final ImageStorage imageStorage) {
+            final SequencedSet<ImageStorage> imageStorages = getImageStorages(imageStorage.getCategory());
+            final int determinedMaxCacheSize = determineMaxCacheSize(imageStorage.getCategory());
+
+            if (imageStorages.add(imageStorage)) {
+                LOG.info("Added {}", imageStorage);
+
+                while (determinedMaxCacheSize < imageStorages.size()) {
+                    // remove last since comparator is sorting by DESC timestamp
+                    // thus the oldest and thus smallest value is at the end
+                    // and we keep the newest entries only
+                    imageStorages.removeLast();
+                }
+            }
+        }
+
+        @Override
+        public final Access getAccess(final String category) {
+            return new Access() {
+                private final SequencedSet<ImageStorage> imageStorages = getImageStorages(category);
+
+                @Override
+                public final int count() {
+                    return imageStorages.size();
+                }
+
+                @Override
+                public final List<ImageStorage> getImages(final int maxCount) {
+                    return imageStorages.stream()
+                            .limit(maxCount)
+                            .toList();
+                }
+            };
+        }
+
+        /**
+         * Determines the max cache size for the cache of the given
+         * {@code category}. By default every cache uses the same max size.
+         *
+         * @param category the category for the determination
+         *
+         * @return the determined max cache size for the category
+         */
+        protected int determineMaxCacheSize(final String category) {
+            return maxCacheSize;
+        }
+
+        private final SequencedSet<ImageStorage> getImageStorages(final String category) {
+            Objects.requireNonNull(category, "category must not be null");
+            return categorizedImageStorages.computeIfAbsent(
+                    category,
+                    cat -> new ConcurrentSkipListSet<>(ImageStorage.BY_TIMESTAMP.reversed()));
+        }
+    }
+}


### PR DESCRIPTION
ImageStorage has an category associated with it (defaulting to "DEFAULT"). The associated DataProvider caches instances of it. Using the opinionated base implementation of the DataProvider will cache the newest ImageStorage instance grouped by their category and provides access to retrieve the size of the cache and the newest N elements from the cache.